### PR TITLE
Add support for Azure OpenAI Endpoints

### DIFF
--- a/OpenAI-DotNet-Tests/AzureOpenAITest.cs
+++ b/OpenAI-DotNet-Tests/AzureOpenAITest.cs
@@ -1,0 +1,45 @@
+﻿using NUnit.Framework;
+using OpenAI;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenAI_Tests
+{
+    public class AzureOpenAITest
+    {
+
+        private readonly string prompts = "One Two Three Four Five Six Seven Eight Nine One Two Three Four Five Six Seven Eight";
+
+        [SetUp]
+        public void Setup()
+        {
+            File.WriteAllText(".azureopenai", "Endpoint=xxxx;Key=xxxx;Deployment=xxx");
+        }
+
+        public AzureOpenAIClient LoadAzureOpenAIClient()
+        {
+            var azureOpenAiConfig = string.Join("\n", File.ReadAllLines(".azureopenai")).Split(";").Select(x => x.Split("=")).ToDictionary(x => x[0], y => y[1]);
+
+            return new AzureOpenAIClient(azureOpenAiConfig["Endpoint"], new OpenAIAuthentication(azureOpenAiConfig["Key"]), new Engine(azureOpenAiConfig["Deployment"]));
+        }
+
+        //[Test]
+        public async Task TestAzureOpenAiEngines()
+        {
+            var aoaiClient = LoadAzureOpenAIClient();
+            Assert.IsNotNull(aoaiClient.CompletionEndpoint);
+
+            var result = await aoaiClient.CompletionEndpoint.CreateCompletionAsync(prompts, temperature: 0.1, max_tokens: 5, numOutputs: 5);
+            Assert.IsNotNull(result);
+            Assert.NotNull(result.Completions);
+            Assert.NotZero(result.Completions.Count);
+            Assert.That(result.Completions.Any(c => c.Text.Trim().ToLower().StartsWith("nine")));
+            Console.WriteLine(result);
+        }
+    }
+}

--- a/OpenAI-DotNet/AzureOpenAIClient.cs
+++ b/OpenAI-DotNet/AzureOpenAIClient.cs
@@ -1,0 +1,63 @@
+﻿using OpenAI.Endpoints;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection.Metadata.Ecma335;
+using System.Security.Authentication;
+using System.Text.Json;
+
+namespace OpenAI
+{
+    /// <summary>
+    /// Entry point to the Azure OpenAI API, handling auth and allowing access to the various API endpoints
+    /// See documentation here: https://docs.microsoft.com/en-us/azure/cognitive-services/openai/reference
+    /// </summary>
+    public class AzureOpenAIClient : BaseOpenAIClient, ICompletionEndpoint
+    {
+
+        /// <summary>
+        /// Creates a new entry point to the OpenAPI API, handling auth and allowing access to the various API endpoints
+        /// </summary>
+        /// <param name="endpointName"> The endpiont of the api, usually takes the form of https://xxxxx.openai.azure.com</param>
+        /// <param name="authentication">The API authentication information to use for API calls,
+        /// or <see langword="null"/> to attempt to use the <see cref="OpenAIAuthentication.Default"/>,
+        /// potentially loading from environment vars or from a config file.</param>
+        /// <param name="defaultEngine">The <see cref="Engine"/>/model to use for API calls,        
+        /// defaulting to <see cref="Engine.Davinci"/> if not specified.</param>
+        /// <param name="version"/> Version of the api</param>
+        /// <exception cref="AuthenticationException">Raised when authentication details are missing or invalid.</exception>
+        public AzureOpenAIClient(string endpointName, OpenAIAuthentication authentication = null, Engine defaultEngine = null, string version = "2022-06-01-preview") : base(version, authentication, defaultEngine)
+        {
+            EndpointName = endpointName;            
+            CompletionEndpoint = new CompletionEndpoint(this, engine => $"{BaseUrl}deployments/{engine.EngineName}/completions?api-version={Version}");
+        }
+
+        /// <summary>
+        /// The BaseUrl of the Azure Open AI Service
+        /// </summary>
+        public string EndpointName { get; private set; }
+
+        /// <summary>
+        /// The base url for the Azure OpenAI service
+        /// This url takes the form of https://xxx.openai.azure.com/
+        /// </summary>
+        public string BaseUrl
+        {
+            get
+            {
+                return $"{EndpointName}openai/";
+            }
+        }    
+
+        /// <summary>
+        /// Internal add authorization method, adds the api-key to the header for the Azure OpenAI endpoint
+        /// </summary>
+        /// <param name="headers"></param>
+        /// <param name="openAIAuthentication"></param>
+        internal override void AddAuthorization(HttpRequestHeaders headers, OpenAIAuthentication openAIAuthentication)
+        {
+            headers.Add("api-key", Auth.ApiKey);
+        }               
+
+        public CompletionEndpoint CompletionEndpoint { get; }
+    }
+}

--- a/OpenAI-DotNet/BaseEndPoint.cs
+++ b/OpenAI-DotNet/BaseEndPoint.cs
@@ -1,20 +1,44 @@
-﻿namespace OpenAI
+﻿using System;
+
+namespace OpenAI
 {
     public abstract class BaseEndPoint
     {
-        protected readonly OpenAIClient Api;
+        protected readonly BaseOpenAIClient Api;
+
+        /// <summary>
+        /// Delegate method for creating Url's dynamically for a given engine deployment type.
+        /// </summary>
+        /// <param name="deployment"></param>
+        /// <returns></returns>
+        public delegate string UrlGenerator(Engine deployment);
+
+        /// <summary>
+        /// The Url Generator for each endpoint, changes based on whether the service is OAI or AOAI
+        /// </summary>
+        protected readonly UrlGenerator Generator;
 
         /// <summary>
         /// Constructor of the api endpoint.
         /// Rather than instantiating this yourself, access it through an instance of <see cref="OpenAIClient"/>.
         /// </summary>
-        internal BaseEndPoint(OpenAIClient api) => Api = api;
+        internal BaseEndPoint(BaseOpenAIClient api, UrlGenerator generator)
+        {
+            Api = api;
+            Generator = generator;
+
+        } 
 
         /// <summary>
         /// Gets the basic endpoint url for the API
         /// </summary>
         /// <param name="engine">Optional, Engine to use for endpoint.</param>
         /// <returns>The completed basic url for the endpoint.</returns>
-        protected abstract string GetEndpoint(Engine engine = null);
+        protected string GetEndpoint(Engine engine = null)
+        {
+            return Generator(engine ?? Api.DefaultEngine);
+        }
+
+
     }
 }

--- a/OpenAI-DotNet/BaseOpenAIClient.cs
+++ b/OpenAI-DotNet/BaseOpenAIClient.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Authentication;
+using System.Text.Json;
+
+namespace OpenAI
+{
+    public abstract class BaseOpenAIClient
+    {
+
+        /// <summary>
+        /// Creates a new entry point to the OpenAPI API, handling auth and allowing access to the various API endpoints
+        /// </summary>
+        /// <param name="version">The version of the underlying endpoint</param>
+        /// <param name="authentication">The API authentication information to use for API calls,
+        /// or <see langword="null"/> to attempt to use the <see cref="OpenAIAuthentication.Default"/>,
+        /// potentially loading from environment vars or from a config file.</param>
+        /// <param name="defaultEngine">The <see cref="Engine"/>/model to use for API calls,
+        /// defaulting to <see cref="Engine.Davinci"/> if not specified.</param>
+        /// <exception cref="AuthenticationException">Raised when authentication details are missing or invalid.</exception>
+        public BaseOpenAIClient(string version, OpenAIAuthentication authentication = null, Engine defaultEngine = null)
+        {
+            Version = version;
+            Auth = authentication ?? OpenAIAuthentication.Default;
+
+            if (Auth?.ApiKey is null)
+            {
+                throw new AuthenticationException("You must provide API authentication.  Please refer to https://github.com/RageAgainstThePixel/OpenAI-DotNet#authentication for details.");
+            }
+
+            Client = new HttpClient();
+            AddAuthorization(Client.DefaultRequestHeaders, Auth);
+            Client.DefaultRequestHeaders.Add("User-Agent", "dotnet_openai_api");
+            JsonSerializationOptions = new JsonSerializerOptions { IgnoreNullValues = true };
+            DefaultEngine = defaultEngine ?? Engine.Default;
+        }
+
+        /// <summary>
+        /// Provides support to add auth key for each type
+        /// </summary>
+        /// <param name="headers"></param>
+        /// <param name="openAIAuthentication"></param>
+        internal abstract void AddAuthorization(HttpRequestHeaders headers, OpenAIAuthentication openAIAuthentication);
+
+        /// <summary>
+        /// The version of the Api
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// The API authentication information to use for API calls
+        /// </summary>
+        public OpenAIAuthentication Auth { get; private set; }
+
+        /// <summary>
+        /// Specifies which <see cref="Engine"/>/model to use for API calls
+        /// </summary>
+        public Engine DefaultEngine { get; set; }
+
+        /// <summary>
+        /// <see cref="HttpClient"/> to use when making calls to the API.
+        /// </summary>
+        internal HttpClient Client { get; }
+
+        /// <summary>
+        /// The <see cref="JsonSerializationOptions"/> to use when making calls to the API.
+        /// </summary>
+        internal JsonSerializerOptions JsonSerializationOptions { get; }
+
+    }
+}

--- a/OpenAI-DotNet/Classifications/ClassificationEndpoint.cs
+++ b/OpenAI-DotNet/Classifications/ClassificationEndpoint.cs
@@ -13,13 +13,8 @@ namespace OpenAI
     public class ClassificationEndpoint : BaseEndPoint
     {
         /// <inheritdoc />
-        internal ClassificationEndpoint(OpenAIClient api) : base(api) { }
+        internal ClassificationEndpoint(BaseOpenAIClient api,UrlGenerator generator) : base(api,generator) { }
 
-        /// <inheritdoc />
-        protected override string GetEndpoint(Engine engine = null)
-        {
-            return $"{Api.BaseUrl}classifications";
-        }
 
         /// <summary>
         /// Given a query and a set of labeled examples, the model will predict the most likely label for the query.

--- a/OpenAI-DotNet/Completions/CompletionEndpoint.cs
+++ b/OpenAI-DotNet/Completions/CompletionEndpoint.cs
@@ -18,13 +18,8 @@ namespace OpenAI
     public class CompletionEndpoint : BaseEndPoint
     {
         /// <inheritdoc />
-        internal CompletionEndpoint(OpenAIClient api) : base(api) { }
-
-        /// <inheritdoc />
-        protected override string GetEndpoint(Engine engine = null)
-        {
-            return $"{Api.BaseUrl}engines/{engine?.EngineName ?? Api.DefaultEngine.EngineName}/completions";
-        }
+        internal CompletionEndpoint(BaseOpenAIClient api,UrlGenerator generator) : base(api,generator) { }
+        
 
         #region Non-streaming
 

--- a/OpenAI-DotNet/Endpoints/IClassificationEndpoint.cs
+++ b/OpenAI-DotNet/Endpoints/IClassificationEndpoint.cs
@@ -1,0 +1,17 @@
+﻿using OpenAI;
+
+namespace OpenAI.Endpoints
+{
+    public interface IClassificationEndpoint
+    {
+        /// <summary>
+        /// This endpoint provides the ability to leverage a labeled set of examples without fine-tuning and can be
+        /// used for any text-to-label task. By avoiding fine-tuning, it eliminates the need for hyper-parameter tuning.
+        /// The endpoint serves as an "autoML" solution that is easy to configure, and adapt to changing label schema.
+        /// Up to 200 labeled examples can be provided at query time. Given a query and a set of labeled examples,
+        /// the model will predict the most likely label for the query. Useful as a drop-in replacement for any ML
+        /// classification or text-to-label task.
+        /// </summary>
+        ClassificationEndpoint ClassificationEndpoint { get; }
+    }
+}

--- a/OpenAI-DotNet/Endpoints/ICompletionEndpoint.cs
+++ b/OpenAI-DotNet/Endpoints/ICompletionEndpoint.cs
@@ -1,0 +1,17 @@
+﻿using OpenAI;
+
+namespace OpenAI.Endpoints
+{
+    public interface ICompletionEndpoint
+    {
+        /// <summary>
+        /// Text generation is the core function of the API.
+        /// You give the API a prompt, and it generates a completion.
+        /// The way you “program” the API to do a task is by simply describing the task in plain english
+        /// or providing a few written examples. This simple approach works for a wide range of use cases,
+        /// including summarization, translation, grammar correction, question answering, chatbots, composing emails,
+        /// and much more (see the prompt library for inspiration).
+        /// </summary>
+        CompletionEndpoint CompletionEndpoint { get; }
+    }
+}

--- a/OpenAI-DotNet/Endpoints/IEngineEndpoint.cs
+++ b/OpenAI-DotNet/Endpoints/IEngineEndpoint.cs
@@ -1,0 +1,16 @@
+﻿using OpenAI;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenAI.Endpoints
+{
+
+    public interface IEnginerEndpoint
+    {
+        /// <summary>
+        /// The API endpoint for querying available Engines/models
+        /// </summary>
+        EnginesEndpoint EnginesEndpoint { get; }
+    }
+}

--- a/OpenAI-DotNet/Endpoints/ISearchEndpoint.cs
+++ b/OpenAI-DotNet/Endpoints/ISearchEndpoint.cs
@@ -1,0 +1,18 @@
+﻿using OpenAI;
+
+namespace OpenAI.Endpoints
+{
+    public interface ISearchEndpoint
+    {
+        /// <summary>
+        /// This endpoint lets you do semantic search over documents. This means that you can provide a query,
+        /// such as a natural language question or a statement, and find documents that answer the question
+        /// or are semantically related to the statement. The “documents” can be words, sentences, paragraphs
+        /// or even longer documents. For example, if you provide documents "White House", "hospital", "school"
+        /// and query "the president", you’ll get a different similarity score for each document.
+        /// The higher the similarity score, the more semantically similar the document is to the query
+        /// (in this example, “White House” will be most similar to “the president”).
+        /// </summary>
+        SearchEndpoint SearchEndpoint { get; }
+    }
+}

--- a/OpenAI-DotNet/Engine/EnginesEndpoint.cs
+++ b/OpenAI-DotNet/Engine/EnginesEndpoint.cs
@@ -20,13 +20,7 @@ namespace OpenAI
         }
 
         /// <inheritdoc />
-        internal EnginesEndpoint(OpenAIClient api) : base(api) { }
-
-        /// <inheritdoc />
-        protected override string GetEndpoint(Engine engine = null)
-        {
-            return $"{Api.BaseUrl}engines";
-        }
+        internal EnginesEndpoint(BaseOpenAIClient api,UrlGenerator generator) : base(api,generator) { }
 
         /// <summary>
         /// List all engines via the API

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -22,10 +22,14 @@ Renamed Authentication to OpenAIAuthentication</PackageReleaseNotes>
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
     <PackageId>OpenAI-DotNet</PackageId>
-    <Version>3.0.1</Version>
-    <AssemblyVersion>3.0.1.0</AssemblyVersion>
-    <FileVersion>3.0.1.0</FileVersion>
+    <Version>3.0.2</Version>
+    <AssemblyVersion>3.0.2.0</AssemblyVersion>
+    <FileVersion>3.0.2.0</FileVersion>
     <Company>RageAgainstThePixel</Company>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Service\" />
+  </ItemGroup>
 
 </Project>

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using OpenAI.Endpoints;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Authentication;
 using System.Text.Json;
@@ -8,15 +9,17 @@ namespace OpenAI
     /// <summary>
     /// Entry point to the OpenAI API, handling auth and allowing access to the various API endpoints
     /// </summary>
-    public class OpenAIClient
+    public class OpenAIClient : BaseOpenAIClient, IEnginerEndpoint, ICompletionEndpoint, ISearchEndpoint, IClassificationEndpoint
     {
+
         /// <summary>
         /// Creates a new entry point to the OpenAPI API, handling auth and allowing access to the various API endpoints
         /// </summary>
-        /// <param name="engine">The <see cref="Engine"/>/model to use for API calls,
+        /// <param name="version">The version for the api, defaults to 1 </param>
+        /// <param name="defaultEngine">The <see cref="Engine"/>/model to use for API calls,
         /// defaulting to <see cref="Engine.Davinci"/> if not specified.</param>
         /// <exception cref="AuthenticationException">Raised when authentication details are missing or invalid.</exception>
-        public OpenAIClient(Engine engine) : this(null, engine) { }
+        public OpenAIClient(Engine defaultEngine, string version = "1") : this(null, defaultEngine, version) { }
 
         /// <summary>
         /// Creates a new entry point to the OpenAPI API, handling auth and allowing access to the various API endpoints
@@ -25,104 +28,43 @@ namespace OpenAI
         /// or <see langword="null"/> to attempt to use the <see cref="OpenAIAuthentication.Default"/>,
         /// potentially loading from environment vars or from a config file.</param>
         /// <param name="engine">The <see cref="Engine"/>/model to use for API calls,
+        /// <paramref name="version"/> Version of the api, defaults to 1 </param>
         /// defaulting to <see cref="Engine.Davinci"/> if not specified.</param>
         /// <exception cref="AuthenticationException">Raised when authentication details are missing or invalid.</exception>
-        public OpenAIClient(OpenAIAuthentication authentication = null, Engine engine = null)
+        public OpenAIClient(OpenAIAuthentication authentication = null, Engine engine = null, string version = "1") : base(version, authentication, engine)
         {
-            Auth = authentication ?? OpenAIAuthentication.Default;
-
-            if (Auth?.ApiKey is null)
-            {
-                throw new AuthenticationException("You must provide API authentication.  Please refer to https://github.com/RageAgainstThePixel/OpenAI-DotNet#authentication for details.");
-            }
-
-            Client = new HttpClient();
-            Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Auth.ApiKey);
-            Client.DefaultRequestHeaders.Add("User-Agent", "dotnet_openai_api");
-            Version = 1;
-            JsonSerializationOptions = new JsonSerializerOptions { IgnoreNullValues = true };
 
             DefaultEngine = engine ?? Engine.Default;
-            EnginesEndpoint = new EnginesEndpoint(this);
-            CompletionEndpoint = new CompletionEndpoint(this);
-            SearchEndpoint = new SearchEndpoint(this);
-            ClassificationEndpoint = new ClassificationEndpoint(this);
+            EnginesEndpoint = new EnginesEndpoint(this, engine => $"{BaseUrl}engines");
+            CompletionEndpoint = new CompletionEndpoint(this, engine => $"{BaseUrl}engines/{engine.EngineName}/completions");
+            SearchEndpoint = new SearchEndpoint(this, engine => $"{BaseUrl}engines/{engine.EngineName}/search");
+            ClassificationEndpoint = new ClassificationEndpoint(this, engine => $"{BaseUrl}classifications");
         }
-
-        /// <summary>
-        /// The API authentication information to use for API calls
-        /// </summary>
-        public OpenAIAuthentication Auth { get; }
-
-        /// <summary>
-        /// Specifies which <see cref="Engine"/>/model to use for API calls
-        /// </summary>
-        public Engine DefaultEngine { get; set; }
-
-        private int version;
 
         /// <summary>
         /// Specifies which version of the API to use.
         /// </summary>
-        public int Version
+        public string BaseUrl
         {
-            get => version;
-            set
-            {
-                version = value;
-                BaseUrl = $"https://api.openai.com/v{version}/";
-            }
+            get => $"https://api.openai.com/v{Version}/";
+        }
+        /// <summary>
+        /// Internal function to generate proper authentication header
+        /// </summary>
+        /// <param name="headers"></param>
+        /// <param name="auth"></param>
+        internal override void AddAuthorization(HttpRequestHeaders headers, OpenAIAuthentication auth)
+        {
+            headers.Authorization = new AuthenticationHeaderValue("Bearer", auth.ApiKey);
         }
 
-        /// <summary>
-        /// The API endpoint for querying available Engines/models
-        /// </summary>
         public EnginesEndpoint EnginesEndpoint { get; }
 
-        /// <summary>
-        /// Text generation is the core function of the API.
-        /// You give the API a prompt, and it generates a completion.
-        /// The way you “program” the API to do a task is by simply describing the task in plain english
-        /// or providing a few written examples. This simple approach works for a wide range of use cases,
-        /// including summarization, translation, grammar correction, question answering, chatbots, composing emails,
-        /// and much more (see the prompt library for inspiration).
-        /// </summary>
         public CompletionEndpoint CompletionEndpoint { get; }
 
-        /// <summary>
-        /// This endpoint lets you do semantic search over documents. This means that you can provide a query,
-        /// such as a natural language question or a statement, and find documents that answer the question
-        /// or are semantically related to the statement. The “documents” can be words, sentences, paragraphs
-        /// or even longer documents. For example, if you provide documents "White House", "hospital", "school"
-        /// and query "the president", you’ll get a different similarity score for each document.
-        /// The higher the similarity score, the more semantically similar the document is to the query
-        /// (in this example, “White House” will be most similar to “the president”).
-        /// </summary>
         public SearchEndpoint SearchEndpoint { get; }
 
-        /// <summary>
-        /// This endpoint provides the ability to leverage a labeled set of examples without fine-tuning and can be
-        /// used for any text-to-label task. By avoiding fine-tuning, it eliminates the need for hyper-parameter tuning.
-        /// The endpoint serves as an "autoML" solution that is easy to configure, and adapt to changing label schema.
-        /// Up to 200 labeled examples can be provided at query time. Given a query and a set of labeled examples,
-        /// the model will predict the most likely label for the query. Useful as a drop-in replacement for any ML
-        /// classification or text-to-label task.
-        /// </summary>
         public ClassificationEndpoint ClassificationEndpoint { get; }
 
-        /// <summary>
-        /// <see cref="HttpClient"/> to use when making calls to the API.
-        /// </summary>
-        internal HttpClient Client { get; }
-
-        /// <summary>
-        /// The base url to use when making calls to the API.
-        /// </summary>
-        internal string BaseUrl { get; private set; }
-
-        /// <summary>
-        /// The <see cref="JsonSerializationOptions"/> to use when making calls to the API.
-        /// </summary>
-        internal JsonSerializerOptions JsonSerializationOptions { get; }
     }
 }

--- a/OpenAI-DotNet/ResponseExtensions.cs
+++ b/OpenAI-DotNet/ResponseExtensions.cs
@@ -12,9 +12,22 @@ namespace OpenAI
 
         internal static void SetResponseData(this BaseResponse response, HttpResponseHeaders headers)
         {
-            response.Organization = headers.GetValues(Organization).FirstOrDefault();
-            response.RequestId = headers.GetValues(RequestId).FirstOrDefault();
-            response.ProcessingTime = TimeSpan.FromMilliseconds(int.Parse(headers.GetValues(ProcessingTime).First()));
+            response.Organization = TryGetCaseInsensitive(headers, Organization);
+            response.RequestId = TryGetCaseInsensitive(headers, RequestId);
+            response.ProcessingTime = TimeSpan.FromMilliseconds(double.Parse(TryGetCaseInsensitive(headers, ProcessingTime)));
         }
+
+        internal static string TryGetCaseInsensitive(HttpResponseHeaders headers,string key)
+        {
+            if(headers.TryGetValues(key,out var values))
+            {
+                return values.FirstOrDefault();
+            } else
+            {
+                return headers.GetValues(key.ToLower()).FirstOrDefault();
+            }
+        }
+
+        
     }
 }

--- a/OpenAI-DotNet/Search/SearchEndpoint.cs
+++ b/OpenAI-DotNet/Search/SearchEndpoint.cs
@@ -21,13 +21,8 @@ namespace OpenAI
     public class SearchEndpoint : BaseEndPoint
     {
         /// <inheritdoc />
-        internal SearchEndpoint(OpenAIClient api) : base(api) { }
+        internal SearchEndpoint(BaseOpenAIClient api, UrlGenerator generator) : base(api,generator) { }
 
-        /// <inheritdoc />
-        protected override string GetEndpoint(Engine engine = null)
-        {
-            return $"{Api.BaseUrl}engines/{engine?.EngineName ?? Api.DefaultEngine.EngineName}/search";
-        }
 
         /// <summary>
         /// Perform a semantic search over a list of documents


### PR DESCRIPTION
Refactor the library to support both the OpenAI and Azure OpenAI endpoints.  There are no functional changes to any of the OpenAI calls.
High level overview:

- Changed OpenAIClient to now extend from BaseOpenAIClient.  Added a second class for AzureOpenAIClient.  Most logic moved into BaseOpenAIEndpoint class.
- BaseEndPoint now takes a delegate UrlGenerator as part of the constructor.  All Url generation moved to BaseEndPoint, with both OpenAIClient and AzureOpenAIClient responsible for passing in the delegate.
- Added IClassificationEndpoint, ICompletionEndPoint, IEngineEndpoint, and ISearchEndpoint to provide interface/compile support on which Client supports which endpoints (this is mostly so users can swap out the Client and still maintain compile time constraints on which client supports which endpoint).
- Small refactorings to support small changes between the endpoint.  For example, how the authorization header is passed in for each endpoint, and a couple of small TryGet's for case insensitivity on the names.
- Added a test case for the AzureOpenAI completion endpoint, although not sure how to support testing of it right now, so I have commented out the [Test] annotation.