### PR TITLE
OpenAI-DotNet 4.3.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: StephenHodgson

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+# Bug Report
+
+## Overview
+<!-- A clear and concise description of what the bug is. -->
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+# Feature Request
+
+## Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+## Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
+
+## Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+## Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/OpenAI-DotNet-Tests/OpenAI-DotNet-Tests.csproj
+++ b/OpenAI-DotNet-Tests/OpenAI-DotNet-Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>
     <LangVersion>latest</LangVersion>

--- a/OpenAI-DotNet-Tests/OpenAI-DotNet-Tests.csproj
+++ b/OpenAI-DotNet-Tests/OpenAI-DotNet-Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>
     <LangVersion>latest</LangVersion>

--- a/OpenAI-DotNet-Tests/TestFixture_07_FineTunes.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_07_FineTunes.cs
@@ -36,7 +36,7 @@ namespace OpenAI.Tests
 
             var fileData = await CreateTestTrainingDataAsync(api);
             var request = new CreateFineTuneJobRequest(fileData);
-            var fineTuneResponse = await api.FineTuningEndpoint.CreateFineTuneAsync(request);
+            var fineTuneResponse = await api.FineTuningEndpoint.CreateFineTuneJobAsync(request);
 
             Assert.IsNotNull(fineTuneResponse);
             var result = await api.FilesEndpoint.DeleteFileAsync(fileData);
@@ -123,7 +123,7 @@ namespace OpenAI.Tests
             {
                 if (job.Status == "pending")
                 {
-                    var result = await api.FineTuningEndpoint.CancelFineTuneJob(job);
+                    var result = await api.FineTuningEndpoint.CancelFineTuneJobAsync(job);
                     Assert.IsNotNull(result);
                     Assert.IsTrue(result);
                     Console.WriteLine($"{job.Id} -> cancelled");
@@ -139,7 +139,7 @@ namespace OpenAI.Tests
 
             var fileData = await CreateTestTrainingDataAsync(api);
             var request = new CreateFineTuneJobRequest(fileData);
-            var fineTuneResponse = await api.FineTuningEndpoint.CreateFineTuneAsync(request);
+            var fineTuneResponse = await api.FineTuningEndpoint.CreateFineTuneJobAsync(request);
             Assert.IsNotNull(fineTuneResponse);
 
             var fineTuneJob = await api.FineTuningEndpoint.RetrieveFineTuneJobInfoAsync(fineTuneResponse);
@@ -169,7 +169,7 @@ namespace OpenAI.Tests
 
             var fileData = await CreateTestTrainingDataAsync(api);
             var request = new CreateFineTuneJobRequest(fileData);
-            var fineTuneResponse = await api.FineTuningEndpoint.CreateFineTuneAsync(request);
+            var fineTuneResponse = await api.FineTuningEndpoint.CreateFineTuneJobAsync(request);
             Assert.IsNotNull(fineTuneResponse);
 
             var fineTuneJob = await api.FineTuningEndpoint.RetrieveFineTuneJobInfoAsync(fineTuneResponse);

--- a/OpenAI-DotNet/Completions/Choice.cs
+++ b/OpenAI-DotNet/Completions/Choice.cs
@@ -7,29 +7,38 @@ namespace OpenAI.Completions
     /// </summary>
     public sealed class Choice
     {
+        [JsonConstructor]
+        public Choice(string text, int index, Logprobs logprobs, string finishReason)
+        {
+            Text = text;
+            Index = index;
+            Logprobs = logprobs;
+            FinishReason = finishReason;
+        }
+
         /// <summary>
         /// The main text of the completion
         /// </summary>
         [JsonPropertyName("text")]
-        public string Text { get; set; }
+        public string Text { get; }
 
         /// <summary>
         /// If multiple completion choices we returned, this is the index withing the various choices
         /// </summary>
         [JsonPropertyName("index")]
-        public int Index { get; set; }
+        public int Index { get; }
 
         /// <summary>
         /// If the request specified <see cref="CompletionRequest.LogProbabilities"/>, this contains the list of the most likely tokens.
         /// </summary>
         [JsonPropertyName("logprobs")]
-        public Logprobs Logprobs { get; set; }
+        public Logprobs Logprobs { get; }
 
         /// <summary>
         /// If this is the last segment of the completion result, this specifies why the completion has ended.
         /// </summary>
         [JsonPropertyName("finish_reason")]
-        public string FinishReason { get; set; }
+        public string FinishReason { get; }
 
         /// <summary>
         /// Gets the main text of this completion

--- a/OpenAI-DotNet/Completions/CompletionRequest.cs
+++ b/OpenAI-DotNet/Completions/CompletionRequest.cs
@@ -103,7 +103,7 @@ namespace OpenAI.Completions
         /// Do not set this yourself, use the appropriate methods on <see cref="CompletionsEndpoint"/> instead.
         /// </summary>
         [JsonPropertyName("stream")]
-        public bool Stream { get; internal set; } = false;
+        public bool Stream { get; internal set; }
 
         /// <summary>
         /// Include the log probabilities on the most likely tokens, which can be found in

--- a/OpenAI-DotNet/Completions/CompletionResult.cs
+++ b/OpenAI-DotNet/Completions/CompletionResult.cs
@@ -9,20 +9,30 @@ namespace OpenAI.Completions
     /// </summary>
     public sealed class CompletionResult : BaseResponse
     {
+        [JsonConstructor]
+        public CompletionResult(string id, string @object, int createdUnixTime, string model, List<Choice> completions)
+        {
+            Id = id;
+            Object = @object;
+            CreatedUnixTime = createdUnixTime;
+            Model = model;
+            Completions = completions;
+        }
+
         /// <summary>
         /// The identifier of the result, which may be used during troubleshooting
         /// </summary>
         [JsonPropertyName("id")]
-        public string Id { get; set; }
+        public string Id { get; }
 
         [JsonPropertyName("object")]
-        public string Object { get; set; }
+        public string Object { get; }
 
         /// <summary>
         /// The time when the result was generated in unix epoch format
         /// </summary>
         [JsonPropertyName("created")]
-        public int CreatedUnixTime { get; set; }
+        public int CreatedUnixTime { get; }
 
         /// <summary>
         /// The time when the result was generated.
@@ -31,13 +41,13 @@ namespace OpenAI.Completions
         public DateTime Created => DateTimeOffset.FromUnixTimeSeconds(CreatedUnixTime).DateTime;
 
         [JsonPropertyName("model")]
-        public string Model { get; set; }
+        public string Model { get; }
 
         /// <summary>
         /// The completions returned by the API.  Depending on your request, there may be 1 or many choices.
         /// </summary>
         [JsonPropertyName("choices")]
-        public List<Choice> Completions { get; set; }
+        public List<Choice> Completions { get; }
 
         /// <summary>
         /// Gets the text of the first completion, representing the main result

--- a/OpenAI-DotNet/Completions/CompletionsEndpoint.cs
+++ b/OpenAI-DotNet/Completions/CompletionsEndpoint.cs
@@ -88,7 +88,7 @@ namespace OpenAI.Completions
                 echo,
                 stopSequences);
 
-            return await CreateCompletionAsync(request);
+            return await CreateCompletionAsync(request).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -103,11 +103,11 @@ namespace OpenAI.Completions
         {
             completionRequest.Stream = false;
             var jsonContent = JsonSerializer.Serialize(completionRequest, Api.JsonSerializationOptions);
-            var response = await Api.Client.PostAsync(GetEndpoint(), jsonContent.ToJsonStringContent());
+            var response = await Api.Client.PostAsync(GetEndpoint(), jsonContent.ToJsonStringContent()).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
             {
-                return DeserializeResult(response, await response.Content.ReadAsStringAsync());
+                return DeserializeResult(response, await response.Content.ReadAsStringAsync().ConfigureAwait(false));
             }
 
             throw new HttpRequestException($"{nameof(CreateCompletionAsync)} Failed! HTTP status code: {response.StatusCode}. Request body: {jsonContent}");
@@ -183,7 +183,7 @@ namespace OpenAI.Completions
                 echo,
                 stopSequences);
 
-            await StreamCompletionAsync(request, resultHandler);
+            await StreamCompletionAsync(request, resultHandler).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -201,14 +201,14 @@ namespace OpenAI.Completions
             {
                 Content = jsonContent.ToJsonStringContent()
             };
-            var response = await Api.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            var response = await Api.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
             {
-                await using var stream = await response.Content.ReadAsStreamAsync();
+                await using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 using var reader = new StreamReader(stream);
 
-                while (await reader.ReadLineAsync() is { } line)
+                while (await reader.ReadLineAsync().ConfigureAwait(false) is { } line)
                 {
                     if (line.StartsWith("data: "))
                     {
@@ -318,14 +318,14 @@ namespace OpenAI.Completions
             {
                 Content = jsonContent.ToJsonStringContent()
             };
-            var response = await Api.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            var response = await Api.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
             {
-                await using var stream = await response.Content.ReadAsStreamAsync();
+                await using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 using var reader = new StreamReader(stream);
 
-                while (await reader.ReadLineAsync() is { } line)
+                while (await reader.ReadLineAsync().ConfigureAwait(false) is { } line)
                 {
                     if (line.StartsWith("data: "))
                     {

--- a/OpenAI-DotNet/Completions/Logprobs.cs
+++ b/OpenAI-DotNet/Completions/Logprobs.cs
@@ -8,16 +8,25 @@ namespace OpenAI.Completions
     /// </summary>
     public sealed class Logprobs
     {
+        [JsonConstructor]
+        public Logprobs(List<string> tokens, List<double> tokenLogprobs, IList<IDictionary<string, double>> topLogprobs, List<int> textOffsets)
+        {
+            Tokens = tokens;
+            TokenLogprobs = tokenLogprobs;
+            TopLogprobs = topLogprobs;
+            TextOffsets = textOffsets;
+        }
+
         [JsonPropertyName("tokens")]
-        public List<string> Tokens { get; set; }
+        public List<string> Tokens { get; }
 
         [JsonPropertyName("token_logprobs")]
-        public List<double> TokenLogprobs { get; set; }
+        public List<double> TokenLogprobs { get; }
 
         [JsonPropertyName("top_logprobs")]
-        public IList<IDictionary<string, double>> TopLogprobs { get; set; }
+        public IList<IDictionary<string, double>> TopLogprobs { get; }
 
         [JsonPropertyName("text_offset")]
-        public List<int> TextOffsets { get; set; }
+        public List<int> TextOffsets { get; }
     }
 }

--- a/OpenAI-DotNet/Edits/Choice.cs
+++ b/OpenAI-DotNet/Edits/Choice.cs
@@ -4,11 +4,18 @@ namespace OpenAI.Edits
 {
     public sealed class Choice
     {
+        [JsonConstructor]
+        public Choice(string text, int index)
+        {
+            Text = text;
+            Index = index;
+        }
+
         [JsonPropertyName("text")]
-        public string Text { get; set; }
+        public string Text { get; }
 
         [JsonPropertyName("index")]
-        public int Index { get; set; }
+        public int Index { get; }
 
         /// <summary>
         /// Gets the main text of this completion

--- a/OpenAI-DotNet/Edits/EditRequest.cs
+++ b/OpenAI-DotNet/Edits/EditRequest.cs
@@ -43,25 +43,25 @@ namespace OpenAI.Edits
         /// ID of the model to use. Defaults to text-davinci-edit-001.
         /// </summary>
         [JsonPropertyName("model")]
-        public string Model { get; set; }
+        public string Model { get; }
 
         /// <summary>
         /// The input text to use as a starting point for the edit.
         /// </summary>
         [JsonPropertyName("input")]
-        public string Input { get; set; }
+        public string Input { get; }
 
         /// <summary>
         /// The instruction that tells the model how to edit the prompt.
         /// </summary>
         [JsonPropertyName("instruction")]
-        public string Instruction { get; set; }
+        public string Instruction { get; }
 
         /// <summary>
         /// How many edits to generate for the input and instruction.
         /// </summary>
         [JsonPropertyName("n")]
-        public int? EditCount { get; set; }
+        public int? EditCount { get; }
 
         /// <summary>
         /// What sampling temperature to use. Higher values means the model will take more risks.
@@ -69,7 +69,7 @@ namespace OpenAI.Edits
         /// We generally recommend altering this or top_p but not both.
         /// </summary>
         [JsonPropertyName("temperature")]
-        public double? Temperature { get; set; }
+        public double? Temperature { get; }
 
         /// <summary>
         /// An alternative to sampling with temperature, called nucleus sampling, where the model considers the
@@ -78,6 +78,6 @@ namespace OpenAI.Edits
         /// We generally recommend altering this or temperature but not both.
         /// </summary>
         [JsonPropertyName("top_p")]
-        public double? TopP { get; set; }
+        public double? TopP { get; }
     }
 }

--- a/OpenAI-DotNet/Edits/EditResponse.cs
+++ b/OpenAI-DotNet/Edits/EditResponse.cs
@@ -6,24 +6,33 @@ namespace OpenAI.Edits
 {
     public sealed class EditResponse : BaseResponse
     {
+        [JsonConstructor]
+        public EditResponse(string @object, int createdUnixTime, List<Choice> choices, Usage usage)
+        {
+            Object = @object;
+            CreatedUnixTime = createdUnixTime;
+            Choices = choices;
+            Usage = usage;
+        }
+
         [JsonPropertyName("object")]
-        public string Object { get; set; }
+        public string Object { get; }
 
         /// <summary>
         /// The time when the result was generated in unix epoch format
         /// </summary>
         [JsonPropertyName("created")]
-        public int CreatedUnixTime { get; set; }
+        public int CreatedUnixTime { get; }
 
         /// The time when the result was generated
         [JsonIgnore]
         public DateTime Created => DateTimeOffset.FromUnixTimeSeconds(CreatedUnixTime).DateTime;
 
         [JsonPropertyName("choices")]
-        public List<Choice> Choices { get; set; }
+        public List<Choice> Choices { get; }
 
         [JsonPropertyName("usage")]
-        public Usage Usage { get; set; }
+        public Usage Usage { get; }
 
         /// <summary>
         /// Gets the text of the first edit, representing the main result

--- a/OpenAI-DotNet/Edits/EditsEndpoint.cs
+++ b/OpenAI-DotNet/Edits/EditsEndpoint.cs
@@ -2,7 +2,6 @@
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
-using OpenAI.Models;
 
 namespace OpenAI.Edits
 {
@@ -47,7 +46,7 @@ namespace OpenAI.Edits
             Model model = null)
         {
             var request = new EditRequest(input, instruction, editCount, temperature, topP, model);
-            var result = await CreateEditAsync(request);
+            var result = await CreateEditAsync(request).ConfigureAwait(false);
             return result.ToString();
         }
 
@@ -59,11 +58,11 @@ namespace OpenAI.Edits
         public async Task<EditResponse> CreateEditAsync(EditRequest request)
         {
             var jsonContent = JsonSerializer.Serialize(request, Api.JsonSerializationOptions);
-            var response = await Api.Client.PostAsync(GetEndpoint(), jsonContent.ToJsonStringContent());
+            var response = await Api.Client.PostAsync(GetEndpoint(), jsonContent.ToJsonStringContent()).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
             {
-                var resultAsString = await response.Content.ReadAsStringAsync();
+                var resultAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var editResponse = JsonSerializer.Deserialize<EditResponse>(resultAsString, Api.JsonSerializationOptions);
 
                 if (editResponse == null)

--- a/OpenAI-DotNet/Embeddings/Datum.cs
+++ b/OpenAI-DotNet/Embeddings/Datum.cs
@@ -5,13 +5,21 @@ namespace OpenAI.Embeddings
 {
     public sealed class Datum
     {
+        [JsonConstructor]
+        public Datum(string @object, IReadOnlyList<double> embedding, int index)
+        {
+            Object = @object;
+            Embedding = embedding;
+            Index = index;
+        }
+
         [JsonPropertyName("object")]
-        public string Object { get; set; }
+        public string Object { get; }
 
         [JsonPropertyName("embedding")]
-        public List<double> Embedding { get; set; }
+        public IReadOnlyList<double> Embedding { get; }
 
         [JsonPropertyName("index")]
-        public int Index { get; set; }
+        public int Index { get; }
     }
 }

--- a/OpenAI-DotNet/Embeddings/EmbeddingsEndpoint.cs
+++ b/OpenAI-DotNet/Embeddings/EmbeddingsEndpoint.cs
@@ -35,7 +35,7 @@ namespace OpenAI.Embeddings
         /// </param>
         /// <returns><see cref="EmbeddingsResponse"/></returns>
         public async Task<EmbeddingsResponse> CreateEmbeddingAsync(string input, Model model = null, string user = null)
-            => await CreateEmbeddingAsync(new EmbeddingsRequest(input, model, user));
+            => await CreateEmbeddingAsync(new EmbeddingsRequest(input, model, user)).ConfigureAwait(false);
 
         /// <summary>
         /// Creates an embedding vector representing the input text.
@@ -44,11 +44,11 @@ namespace OpenAI.Embeddings
         public async Task<EmbeddingsResponse> CreateEmbeddingAsync(EmbeddingsRequest request)
         {
             var jsonContent = JsonSerializer.Serialize(request, Api.JsonSerializationOptions);
-            var response = await Api.Client.PostAsync(GetEndpoint(), jsonContent.ToJsonStringContent());
+            var response = await Api.Client.PostAsync(GetEndpoint(), jsonContent.ToJsonStringContent()).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
             {
-                var resultAsString = await response.Content.ReadAsStringAsync();
+                var resultAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var embeddingsResponse = JsonSerializer.Deserialize<EmbeddingsResponse>(resultAsString, Api.JsonSerializationOptions);
 
                 if (embeddingsResponse == null)

--- a/OpenAI-DotNet/Embeddings/EmbeddingsResponse.cs
+++ b/OpenAI-DotNet/Embeddings/EmbeddingsResponse.cs
@@ -5,16 +5,25 @@ namespace OpenAI.Embeddings
 {
     public sealed class EmbeddingsResponse : BaseResponse
     {
+        [JsonConstructor]
+        public EmbeddingsResponse(string @object, IReadOnlyList<Datum> data, string model, Usage usage)
+        {
+            Object = @object;
+            Data = data;
+            Model = model;
+            Usage = usage;
+        }
+
         [JsonPropertyName("object")]
-        public string Object { get; set; }
+        public string Object { get; }
 
         [JsonPropertyName("data")]
-        public List<Datum> Data { get; set; }
+        public IReadOnlyList<Datum> Data { get; }
 
         [JsonPropertyName("model")]
-        public string Model { get; set; }
+        public string Model { get; }
 
         [JsonPropertyName("usage")]
-        public Usage Usage { get; set; }
+        public Usage Usage { get; }
     }
 }

--- a/OpenAI-DotNet/Files/FileData.cs
+++ b/OpenAI-DotNet/Files/FileData.cs
@@ -5,29 +5,41 @@ namespace OpenAI.Files
 {
     public sealed class FileData
     {
+        [JsonConstructor]
+        public FileData(string id, string @object, int size, int createdUnixTime, string fileName, string purpose, string status)
+        {
+            Id = id;
+            Object = @object;
+            Size = size;
+            CreatedUnixTime = createdUnixTime;
+            FileName = fileName;
+            Purpose = purpose;
+            Status = status;
+        }
+
         [JsonPropertyName("id")]
-        public string Id { get; set; }
+        public string Id { get; }
 
         [JsonPropertyName("object")]
-        public string Object { get; set; }
+        public string Object { get; }
 
         [JsonPropertyName("bytes")]
-        public int Size { get; set; }
+        public int Size { get; }
 
         [JsonPropertyName("created_at")]
-        public int CreatedUnixTime { get; set; }
+        public int CreatedUnixTime { get; }
 
         [JsonIgnore]
         public DateTime CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedUnixTime).DateTime;
 
         [JsonPropertyName("filename")]
-        public string FileName { get; set; }
+        public string FileName { get; }
 
         [JsonPropertyName("purpose")]
-        public string Purpose { get; set; }
+        public string Purpose { get; }
 
         [JsonPropertyName("status")]
-        public string Status { get; set; }
+        public string Status { get; }
 
         public static implicit operator string(FileData fileData) => fileData.Id;
     }

--- a/OpenAI-DotNet/FineTuning/FineTuneJob.cs
+++ b/OpenAI-DotNet/FineTuning/FineTuneJob.cs
@@ -7,47 +7,65 @@ namespace OpenAI.FineTuning
 {
     public sealed class FineTuneJob
     {
+        [JsonConstructor]
+        public FineTuneJob(string id, string @object, string model, int createdAtUnixTime, IReadOnlyList<Event> events, string fineTunedModel, HyperParams hyperParams, string organizationId, IReadOnlyList<FileData> resultFiles, string status, IReadOnlyList<FileData> validationFiles, IReadOnlyList<FileData> trainingFiles, int updatedAtUnixTime)
+        {
+            Id = id;
+            Object = @object;
+            Model = model;
+            CreatedAtUnixTime = createdAtUnixTime;
+            Events = events;
+            FineTunedModel = fineTunedModel;
+            HyperParams = hyperParams;
+            OrganizationId = organizationId;
+            ResultFiles = resultFiles;
+            Status = status;
+            ValidationFiles = validationFiles;
+            TrainingFiles = trainingFiles;
+            UpdatedAtUnixTime = updatedAtUnixTime;
+        }
+
         [JsonPropertyName("id")]
-        public string Id { get; set; }
+        public string Id { get; }
 
         [JsonPropertyName("object")]
-        public string Object { get; set; }
+        public string Object { get; }
 
         [JsonPropertyName("model")]
-        public string Model { get; set; }
+        public string Model { get; }
 
         [JsonPropertyName("created_at")]
-        public int CreatedAtUnixTime { get; set; }
+        public int CreatedAtUnixTime { get; }
 
         [JsonIgnore]
         public DateTime CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnixTime).DateTime;
 
         [JsonPropertyName("events")]
-        public IReadOnlyList<Event> Events { get; set; }
+        public IReadOnlyList<Event> Events { get; }
 
         [JsonPropertyName("fine_tuned_model")]
-        public string FineTunedModel { get; set; }
+        public string FineTunedModel { get; }
 
         [JsonPropertyName("hyperparams")]
-        public HyperParams HyperParams { get; set; }
+        public HyperParams HyperParams { get; }
 
         [JsonPropertyName("organization_id")]
         public string OrganizationId { get; set; }
 
         [JsonPropertyName("result_files")]
-        public IReadOnlyList<FileData> ResultFiles { get; set; }
+        public IReadOnlyList<FileData> ResultFiles { get; }
 
         [JsonPropertyName("status")]
         public string Status { get; set; }
 
         [JsonPropertyName("validation_files")]
-        public IReadOnlyList<FileData> ValidationFiles { get; set; }
+        public IReadOnlyList<FileData> ValidationFiles { get; }
 
         [JsonPropertyName("training_files")]
-        public IReadOnlyList<FileData> TrainingFiles { get; set; }
+        public IReadOnlyList<FileData> TrainingFiles { get; }
 
         [JsonPropertyName("updated_at")]
-        public int UpdatedAtUnixTime { get; set; }
+        public int UpdatedAtUnixTime { get; }
 
         [JsonIgnore]
         public DateTime UpdatedAt => DateTimeOffset.FromUnixTimeSeconds(UpdatedAtUnixTime).DateTime;

--- a/OpenAI-DotNet/FineTuning/FineTuneJob.cs
+++ b/OpenAI-DotNet/FineTuning/FineTuneJob.cs
@@ -50,7 +50,7 @@ namespace OpenAI.FineTuning
         public HyperParams HyperParams { get; }
 
         [JsonPropertyName("organization_id")]
-        public string OrganizationId { get; set; }
+        public string OrganizationId { get; }
 
         [JsonPropertyName("result_files")]
         public IReadOnlyList<FileData> ResultFiles { get; }
@@ -69,5 +69,7 @@ namespace OpenAI.FineTuning
 
         [JsonIgnore]
         public DateTime UpdatedAt => DateTimeOffset.FromUnixTimeSeconds(UpdatedAtUnixTime).DateTime;
+
+        public static implicit operator string(FineTuneJob job) => job.Id;
     }
 }

--- a/OpenAI-DotNet/FineTuning/FineTuneJobResponse.cs
+++ b/OpenAI-DotNet/FineTuning/FineTuneJobResponse.cs
@@ -8,67 +8,83 @@ namespace OpenAI.FineTuning
 {
     public sealed class FineTuneJobResponse : BaseResponse
     {
-        public static implicit operator FineTuneJob(FineTuneJobResponse jobResponse)
-            => new FineTuneJob
-            {
-                Id = jobResponse.Id,
-                Object = jobResponse.Object,
-                Model = jobResponse.Model,
-                CreatedAtUnixTime = jobResponse.CreatedUnixTime,
-                Events = jobResponse.Events.ToList(),
-                FineTunedModel = jobResponse.FineTunedModel,
-                HyperParams = jobResponse.HyperParams,
-                OrganizationId = jobResponse.OrganizationId,
-                ResultFiles = jobResponse.ResultFiles.ToList(),
-                Status = jobResponse.Status,
-                ValidationFiles = jobResponse.ValidationFiles.ToList(),
-                TrainingFiles = jobResponse.TrainingFiles.ToList(),
-                UpdatedAtUnixTime = jobResponse.UpdatedAtUnixTime
-            };
+        [JsonConstructor]
+        public FineTuneJobResponse(string id, string @object, string model, int createdUnixTime, IReadOnlyList<Event> events, string fineTunedModel, HyperParams hyperParams, string organizationId, IReadOnlyList<FileData> resultFiles, string status, IReadOnlyList<FileData> validationFiles, IReadOnlyList<FileData> trainingFiles, int updatedAtUnixTime)
+        {
+            Id = id;
+            Object = @object;
+            Model = model;
+            CreatedUnixTime = createdUnixTime;
+            Events = events;
+            FineTunedModel = fineTunedModel;
+            HyperParams = hyperParams;
+            OrganizationId = organizationId;
+            ResultFiles = resultFiles;
+            Status = status;
+            ValidationFiles = validationFiles;
+            TrainingFiles = trainingFiles;
+            UpdatedAtUnixTime = updatedAtUnixTime;
+        }
 
         [JsonPropertyName("id")]
-        public string Id { get; set; }
+        public string Id { get; }
 
         [JsonPropertyName("object")]
-        public string Object { get; set; }
+        public string Object { get; }
 
         [JsonPropertyName("model")]
-        public string Model { get; set; }
+        public string Model { get; }
 
         [JsonPropertyName("created_at")]
-        public int CreatedUnixTime { get; set; }
+        public int CreatedUnixTime { get; }
 
         [JsonIgnore]
         public DateTime CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedUnixTime).DateTime;
 
         [JsonPropertyName("events")]
-        public IReadOnlyList<Event> Events { get; set; }
+        public IReadOnlyList<Event> Events { get; }
 
         [JsonPropertyName("fine_tuned_model")]
-        public string FineTunedModel { get; set; }
+        public string FineTunedModel { get; }
 
         [JsonPropertyName("hyperparams")]
-        public HyperParams HyperParams { get; set; }
+        public HyperParams HyperParams { get; }
 
         [JsonPropertyName("organization_id")]
-        public string OrganizationId { get; set; }
+        public string OrganizationId { get; }
 
         [JsonPropertyName("result_files")]
-        public IReadOnlyList<FileData> ResultFiles { get; set; }
+        public IReadOnlyList<FileData> ResultFiles { get; }
 
         [JsonPropertyName("status")]
-        public string Status { get; set; }
+        public string Status { get; }
 
         [JsonPropertyName("validation_files")]
-        public IReadOnlyList<FileData> ValidationFiles { get; set; }
+        public IReadOnlyList<FileData> ValidationFiles { get; }
 
         [JsonPropertyName("training_files")]
-        public IReadOnlyList<FileData> TrainingFiles { get; set; }
+        public IReadOnlyList<FileData> TrainingFiles { get; }
 
         [JsonPropertyName("updated_at")]
-        public int UpdatedAtUnixTime { get; set; }
+        public int UpdatedAtUnixTime { get; }
 
         [JsonIgnore]
         public DateTime UpdatedAt => DateTimeOffset.FromUnixTimeSeconds(UpdatedAtUnixTime).DateTime;
+
+        public static implicit operator FineTuneJob(FineTuneJobResponse jobResponse)
+            => new FineTuneJob(
+                jobResponse.Id,
+                jobResponse.Object,
+                jobResponse.Model,
+                jobResponse.CreatedUnixTime,
+                jobResponse.Events.ToList(),
+                jobResponse.FineTunedModel,
+                jobResponse.HyperParams,
+                jobResponse.OrganizationId,
+                jobResponse.ResultFiles.ToList(),
+                jobResponse.Status,
+                jobResponse.ValidationFiles.ToList(),
+                jobResponse.TrainingFiles.ToList(),
+                jobResponse.UpdatedAtUnixTime);
     }
 }

--- a/OpenAI-DotNet/FineTuning/FineTuneJobResponse.cs
+++ b/OpenAI-DotNet/FineTuning/FineTuneJobResponse.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace OpenAI.FineTuning
 {
-    public sealed class FineTuneJobResponse : BaseResponse
+    internal sealed class FineTuneJobResponse : BaseResponse
     {
         [JsonConstructor]
         public FineTuneJobResponse(string id, string @object, string model, int createdUnixTime, IReadOnlyList<Event> events, string fineTunedModel, HyperParams hyperParams, string organizationId, IReadOnlyList<FileData> resultFiles, string status, IReadOnlyList<FileData> validationFiles, IReadOnlyList<FileData> trainingFiles, int updatedAtUnixTime)

--- a/OpenAI-DotNet/FineTuning/FineTuningEndpoint.cs
+++ b/OpenAI-DotNet/FineTuning/FineTuningEndpoint.cs
@@ -47,7 +47,7 @@ namespace OpenAI.FineTuning
         /// <param name="jobRequest"><see cref="CreateFineTuneJobRequest"/>.</param>
         /// <returns><see cref="FineTuneJob"/>.</returns>
         /// <exception cref="HttpRequestException">.</exception>
-        public async Task<FineTuneJobResponse> CreateFineTuneJobAsync(CreateFineTuneJobRequest jobRequest)
+        public async Task<FineTuneJob> CreateFineTuneJobAsync(CreateFineTuneJobRequest jobRequest)
         {
             var jsonContent = JsonSerializer.Serialize(jobRequest, Api.JsonSerializationOptions);
             var response = await Api.Client.PostAsync(GetEndpoint(), jsonContent.ToJsonStringContent()).ConfigureAwait(false);
@@ -84,12 +84,12 @@ namespace OpenAI.FineTuning
         /// <summary>
         /// Gets info about the fine-tune job.
         /// </summary>
-        /// <param name="fineTuneJob"><see cref="FineTuneJob"/>.</param>
+        /// <param name="jobId"><see cref="FineTuneJob.Id"/>.</param>
         /// <returns><see cref="FineTuneJobResponse"/>.</returns>
-        /// <exception cref="HttpRequestException">.</exception>
-        public async Task<FineTuneJobResponse> RetrieveFineTuneJobInfoAsync(FineTuneJob fineTuneJob)
+        /// <exception cref="HttpRequestException"></exception>
+        public async Task<FineTuneJob> RetrieveFineTuneJobInfoAsync(string jobId)
         {
-            var response = await Api.Client.GetAsync($"{GetEndpoint()}/{fineTuneJob.Id}").ConfigureAwait(false);
+            var response = await Api.Client.GetAsync($"{GetEndpoint()}/{jobId}").ConfigureAwait(false);
             var responseAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
@@ -105,12 +105,12 @@ namespace OpenAI.FineTuning
         /// <summary>
         /// Immediately cancel a fine-tune job.
         /// </summary>
-        /// <param name="fineTuneJob"><see cref="FineTuneJob"/> to cancel.</param>
+        /// <param name="jobId"><see cref="FineTuneJob.Id"/> to cancel.</param>
         /// <returns><see cref="FineTuneJobResponse"/>.</returns>
-        /// <exception cref="HttpRequestException">.</exception>
-        public async Task<bool> CancelFineTuneJobAsync(FineTuneJob fineTuneJob)
+        /// <exception cref="HttpRequestException"></exception>
+        public async Task<bool> CancelFineTuneJobAsync(string jobId)
         {
-            var response = await Api.Client.PostAsync($"{GetEndpoint()}/{fineTuneJob.Id}/cancel", null).ConfigureAwait(false);
+            var response = await Api.Client.PostAsync($"{GetEndpoint()}/{jobId}/cancel", null!).ConfigureAwait(false);
             var responseAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
@@ -126,11 +126,12 @@ namespace OpenAI.FineTuning
         /// <summary>
         /// Get fine-grained status updates for a fine-tune job.
         /// </summary>
-        /// <param name="fineTuneJob"><see cref="FineTuneJob"/>.</param>
+        /// <param name="jobId"><see cref="FineTuneJob.Id"/>.</param>
         /// <returns>List of events for <see cref="FineTuneJob"/>.</returns>
-        public async Task<IReadOnlyList<Event>> ListFineTuneEventsAsync(FineTuneJob fineTuneJob)
+        /// <exception cref="HttpRequestException"></exception>
+        public async Task<IReadOnlyList<Event>> ListFineTuneEventsAsync(string jobId)
         {
-            var response = await Api.Client.GetAsync($"{GetEndpoint()}/{fineTuneJob.Id}/events").ConfigureAwait(false);
+            var response = await Api.Client.GetAsync($"{GetEndpoint()}/{jobId}/events").ConfigureAwait(false);
             var responseAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
@@ -144,13 +145,13 @@ namespace OpenAI.FineTuning
         /// <summary>
         /// Stream the fine-grained status updates for a fine-tune job.
         /// </summary>
-        /// <param name="fineTuneJob"><see cref="FineTuneJob"/>.</param>
+        /// <param name="jobId"><see cref="FineTuneJob.Id"/>.</param>
         /// <param name="fineTuneEventCallback">The event callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <exception cref="HttpRequestException"></exception>
-        public async Task StreamFineTuneEventsAsync(FineTuneJob fineTuneJob, Action<Event> fineTuneEventCallback, CancellationToken cancellationToken = default)
+        public async Task StreamFineTuneEventsAsync(string jobId, Action<Event> fineTuneEventCallback, CancellationToken cancellationToken = default)
         {
-            using var request = new HttpRequestMessage(HttpMethod.Get, $"{GetEndpoint()}/{fineTuneJob.Id}/events?stream=true");
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{GetEndpoint()}/{jobId}/events?stream=true");
             var response = await Api.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
@@ -179,11 +180,11 @@ namespace OpenAI.FineTuning
 
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    var result = await CancelFineTuneJobAsync(fineTuneJob).ConfigureAwait(false);
+                    var result = await CancelFineTuneJobAsync(jobId).ConfigureAwait(false);
 
                     if (!result)
                     {
-                        throw new Exception($"Failed to cancel {fineTuneJob}");
+                        throw new Exception($"Failed to cancel {jobId}");
                     }
                 }
             }
@@ -197,12 +198,12 @@ namespace OpenAI.FineTuning
         /// <summary>
         /// Stream the fine-grained status updates for a fine-tune job.
         /// </summary>
-        /// <param name="fineTuneJob"><see cref="FineTuneJob"/>.</param>
+        /// <param name="jobId"><see cref="FineTuneJob.Id"/>.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <exception cref="HttpRequestException"></exception>
-        public async IAsyncEnumerable<Event> StreamFineTuneEventsEnumerableAsync(FineTuneJob fineTuneJob, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public async IAsyncEnumerable<Event> StreamFineTuneEventsEnumerableAsync(string jobId, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            using var request = new HttpRequestMessage(HttpMethod.Get, $"{GetEndpoint()}/{fineTuneJob.Id}/events?stream=true");
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{GetEndpoint()}/{jobId}/events?stream=true");
             var response = await Api.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
@@ -231,11 +232,11 @@ namespace OpenAI.FineTuning
 
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    var result = await CancelFineTuneJobAsync(fineTuneJob).ConfigureAwait(false);
+                    var result = await CancelFineTuneJobAsync(jobId).ConfigureAwait(false);
 
                     if (!result)
                     {
-                        throw new Exception($"Failed to cancel {fineTuneJob}");
+                        throw new Exception($"Failed to cancel {jobId}");
                     }
                 }
             }

--- a/OpenAI-DotNet/FineTuning/FineTuningTrainingData.cs
+++ b/OpenAI-DotNet/FineTuning/FineTuningTrainingData.cs
@@ -11,29 +11,52 @@ namespace OpenAI.FineTuning
     /// </summary>
     public class FineTuningTrainingData
     {
-        public static implicit operator string(FineTuningTrainingData data) => JsonSerializer.Serialize(data);
-
         /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="prompt">Prompt text.</param>
-        /// <param name="completion">The ideal completion text.</param>
-        public FineTuningTrainingData(string prompt, string completion)
+        /// <param name="completion">
+        /// The ideal completion text which is prefixed with a space, with <see cref="completionSuffix"/>.
+        /// </param>
+        /// <param name="promptSuffix">
+        /// Each prompt should end with a fixed separator to inform the model when the prompt ends and the completion begins.
+        /// A simple separator which generally works well is "\n\n###\n\n". The separator should not appear elsewhere in any prompt.
+        /// The default is "\n\n###\n\n".
+        /// </param>
+        /// <param name="completionSuffix">
+        /// Optional, Each completion should end with a fixed stop sequence to inform the model when the completion ends.
+        /// A stop sequence could be "\n", "###", or any other token that does not appear in any completion. Default is " END".
+        /// </param>
+        public FineTuningTrainingData(string prompt, string completion, string promptSuffix = "\\n\\n###\\n\\n", string completionSuffix = " END")
         {
-            Prompt = $"{prompt}";
-            Completion = $" {completion}";
+            this.prompt = prompt;
+            this.promptSuffix = promptSuffix;
+            this.completion = completion;
+            this.completionSuffix = completionSuffix;
         }
+
+        private readonly string prompt;
+
+        private readonly string promptSuffix;
 
         /// <summary>
         /// Prompt text.
         /// </summary>
         [JsonPropertyName("prompt")]
-        public string Prompt { get; }
+        public string Prompt => $"{prompt}{promptSuffix.Replace("\\n", "\n")}";
+
+        private readonly string completion;
+
+        private readonly string completionSuffix;
 
         /// <summary>
         /// The ideal completion text.
         /// </summary>
         [JsonPropertyName("completion")]
-        public string Completion { get; }
+        public string Completion => $" {completion}{completionSuffix.Replace("\\n", "\n")}";
+
+        public static implicit operator string(FineTuningTrainingData data) => data.ToString();
+
+        public override string ToString() => JsonSerializer.Serialize(this);
     }
 }

--- a/OpenAI-DotNet/FineTuning/HyperParams.cs
+++ b/OpenAI-DotNet/FineTuning/HyperParams.cs
@@ -4,16 +4,25 @@ namespace OpenAI.FineTuning
 {
     public sealed class HyperParams
     {
+        [JsonConstructor]
+        public HyperParams(int? batchSize, double? learningRateMultiplier, int epochs, double promptLossWeight)
+        {
+            BatchSize = batchSize;
+            LearningRateMultiplier = learningRateMultiplier;
+            Epochs = epochs;
+            PromptLossWeight = promptLossWeight;
+        }
+
         [JsonPropertyName("batch_size")]
-        public int? BatchSize { get; set; }
+        public int? BatchSize { get; }
 
         [JsonPropertyName("learning_rate_multiplier")]
-        public double? LearningRateMultiplier { get; set; }
+        public double? LearningRateMultiplier { get; }
 
         [JsonPropertyName("n_epochs")]
-        public int Epochs { get; set; }
+        public int Epochs { get; }
 
         [JsonPropertyName("prompt_loss_weight")]
-        public double PromptLossWeight { get; set; }
+        public double PromptLossWeight { get; }
     }
 }

--- a/OpenAI-DotNet/Images/ImageResult.cs
+++ b/OpenAI-DotNet/Images/ImageResult.cs
@@ -4,7 +4,13 @@ namespace OpenAI.Images
 {
     internal class ImageResult
     {
+        [JsonConstructor]
+        public ImageResult(string url)
+        {
+            Url = url;
+        }
+
         [JsonPropertyName("url")]
-        public string Url { get; set; }
+        public string Url { get; }
     }
 }

--- a/OpenAI-DotNet/Images/ImagesEndpoint.cs
+++ b/OpenAI-DotNet/Images/ImagesEndpoint.cs
@@ -28,7 +28,7 @@ namespace OpenAI.Images
         /// <param name="user">A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.</param>
         /// <returns>An array of generated textures.</returns>
         public async Task<IReadOnlyList<string>> GenerateImageAsync(string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
-            => await GenerateImageAsync(new ImageGenerationRequest(prompt, numberOfResults, size, user));
+            => await GenerateImageAsync(new ImageGenerationRequest(prompt, numberOfResults, size, user)).ConfigureAwait(false);
 
         /// <summary>
         /// Creates an image given a prompt.
@@ -39,10 +39,10 @@ namespace OpenAI.Images
         public async Task<IReadOnlyList<string>> GenerateImageAsync(ImageGenerationRequest request)
         {
             var jsonContent = JsonSerializer.Serialize(request, Api.JsonSerializationOptions);
-            var response = await Api.Client.PostAsync($"{GetEndpoint()}generations", jsonContent.ToJsonStringContent());
+            var response = await Api.Client.PostAsync($"{GetEndpoint()}generations", jsonContent.ToJsonStringContent()).ConfigureAwait(false);
 
             return response.IsSuccessStatusCode
-                ? await DeserializeResponseAsync(response)
+                ? await DeserializeResponseAsync(response).ConfigureAwait(false)
                 : throw new HttpRequestException(
                     $"{nameof(GenerateImageAsync)} Failed!  HTTP status code: {response.StatusCode}. Request body: {jsonContent}");
         }
@@ -71,7 +71,7 @@ namespace OpenAI.Images
         /// <returns>An array of generated textures.</returns>
         /// <exception cref="HttpRequestException"></exception>
         public async Task<IReadOnlyList<string>> CreateImageEditAsync(string image, string mask, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
-            => await CreateImageEditAsync(new ImageEditRequest(image, mask, prompt, numberOfResults, size, user));
+            => await CreateImageEditAsync(new ImageEditRequest(image, mask, prompt, numberOfResults, size, user)).ConfigureAwait(false);
 
         /// <summary>
         /// Creates an edited or extended image given an original image and a prompt.
@@ -83,10 +83,10 @@ namespace OpenAI.Images
         {
             using var content = new MultipartFormDataContent();
             using var imageData = new MemoryStream();
-            await request.Image.CopyToAsync(imageData);
+            await request.Image.CopyToAsync(imageData).ConfigureAwait(false);
             content.Add(new ByteArrayContent(imageData.ToArray()), "image", request.ImageName);
             using var maskData = new MemoryStream();
-            await request.Mask.CopyToAsync(maskData);
+            await request.Mask.CopyToAsync(maskData).ConfigureAwait(false);
             content.Add(new ByteArrayContent(maskData.ToArray()), "mask", request.MaskName);
             content.Add(new StringContent(request.Prompt), "prompt");
             content.Add(new StringContent(request.Number.ToString()), "n");
@@ -99,11 +99,11 @@ namespace OpenAI.Images
 
             request.Dispose();
 
-            var response = await Api.Client.PostAsync($"{GetEndpoint()}edits", content);
-            var responseAsString = await response.Content.ReadAsStringAsync();
+            var response = await Api.Client.PostAsync($"{GetEndpoint()}edits", content).ConfigureAwait(false);
+            var responseAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             return response.IsSuccessStatusCode
-                ? await DeserializeResponseAsync(response)
+                ? await DeserializeResponseAsync(response).ConfigureAwait(false)
                 : throw new HttpRequestException(
                     $"{nameof(CreateImageEditAsync)} Failed!  HTTP status code: {response.StatusCode}. Response: {responseAsString}");
         }
@@ -126,7 +126,7 @@ namespace OpenAI.Images
         /// </param>
         /// <returns></returns>
         public async Task<IReadOnlyList<string>> CreateImageVariationAsync(string imagePath, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
-            => await CreateImageVariationAsync(new ImageVariationRequest(imagePath, numberOfResults, size, user));
+            => await CreateImageVariationAsync(new ImageVariationRequest(imagePath, numberOfResults, size, user)).ConfigureAwait(false);
 
         /// <summary>
         /// Creates a variation of a given image.
@@ -138,7 +138,7 @@ namespace OpenAI.Images
         {
             using var content = new MultipartFormDataContent();
             using var imageData = new MemoryStream();
-            await request.Image.CopyToAsync(imageData);
+            await request.Image.CopyToAsync(imageData).ConfigureAwait(false);
             content.Add(new ByteArrayContent(imageData.ToArray()), "image", request.ImageName);
             content.Add(new StringContent(request.Number.ToString()), "n");
             content.Add(new StringContent(request.Size), "size");
@@ -150,11 +150,11 @@ namespace OpenAI.Images
 
             request.Dispose();
 
-            var response = await Api.Client.PostAsync($"{GetEndpoint()}variations", content);
-            var responseAsString = await response.Content.ReadAsStringAsync();
+            var response = await Api.Client.PostAsync($"{GetEndpoint()}variations", content).ConfigureAwait(false);
+            var responseAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             return response.IsSuccessStatusCode
-                ? await DeserializeResponseAsync(response)
+                ? await DeserializeResponseAsync(response).ConfigureAwait(false)
                 : throw new HttpRequestException(
                     $"{nameof(CreateImageVariationAsync)} Failed!  HTTP status code: {response.StatusCode}. Response: {responseAsString}");
         }
@@ -162,7 +162,7 @@ namespace OpenAI.Images
         private async Task<IReadOnlyList<string>> DeserializeResponseAsync(HttpResponseMessage response)
         {
             Debug.Assert(response.IsSuccessStatusCode);
-            var resultAsString = await response.Content.ReadAsStringAsync();
+            var resultAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             var imagesResponse = JsonSerializer.Deserialize<ImagesResponse>(resultAsString, Api.JsonSerializationOptions);
 
             if (imagesResponse?.Data == null || imagesResponse.Data.Count == 0)

--- a/OpenAI-DotNet/Images/ImagesResponse.cs
+++ b/OpenAI-DotNet/Images/ImagesResponse.cs
@@ -5,10 +5,17 @@ namespace OpenAI.Images
 {
     internal class ImagesResponse : BaseResponse
     {
+        [JsonConstructor]
+        public ImagesResponse(int created, IReadOnlyList<ImageResult> data)
+        {
+            Created = created;
+            Data = data;
+        }
+
         [JsonPropertyName("created")]
-        public int Created { get; set; }
+        public int Created { get; }
 
         [JsonPropertyName("data")]
-        public List<ImageResult> Data { get; set; }
+        public IReadOnlyList<ImageResult> Data { get; }
     }
 }

--- a/OpenAI-DotNet/Models/ModelsEndpoint.cs
+++ b/OpenAI-DotNet/Models/ModelsEndpoint.cs
@@ -54,8 +54,8 @@ namespace OpenAI.Models
         /// <exception cref="HttpRequestException">Raised when the HTTP request fails</exception>
         public async Task<IReadOnlyList<Model>> GetModelsAsync()
         {
-            var response = await Api.Client.GetAsync(GetEndpoint());
-            var responseAsString = await response.Content.ReadAsStringAsync();
+            var response = await Api.Client.GetAsync(GetEndpoint()).ConfigureAwait(false);
+            var responseAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
             {
@@ -73,8 +73,8 @@ namespace OpenAI.Models
         /// <exception cref="HttpRequestException">Raised when the HTTP request fails</exception>
         public async Task<Model> GetModelDetailsAsync(string id)
         {
-            var response = await Api.Client.GetAsync($"{GetEndpoint()}/{id}");
-            var responseAsString = await response.Content.ReadAsStringAsync();
+            var response = await Api.Client.GetAsync($"{GetEndpoint()}/{id}").ConfigureAwait(false);
+            var responseAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
             {
@@ -92,7 +92,7 @@ namespace OpenAI.Models
         /// <exception cref="HttpRequestException"></exception>
         public async Task<bool> DeleteFineTuneModelAsync(string modelId)
         {
-            var model = await GetModelDetailsAsync(modelId);
+            var model = await GetModelDetailsAsync(modelId).ConfigureAwait(false);
 
             if (model == null)
             {
@@ -104,8 +104,8 @@ namespace OpenAI.Models
                 throw new UnauthorizedAccessException($"{model.Id} is not owned by your organization.");
             }
 
-            var response = await Api.Client.DeleteAsync($"{GetEndpoint()}/{model.Id}");
-            var responseAsString = await response.Content.ReadAsStringAsync();
+            var response = await Api.Client.DeleteAsync($"{GetEndpoint()}/{model.Id}").ConfigureAwait(false);
+            var responseAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
             {

--- a/OpenAI-DotNet/Models/Permission.cs
+++ b/OpenAI-DotNet/Models/Permission.cs
@@ -1,15 +1,16 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace OpenAI.Models
 {
     public sealed class Permission
     {
         [JsonConstructor]
-        public Permission(string id, string @object, int created, bool allowCreateEngine, bool allowSampling, bool allowLogprobs, bool allowSearchIndices, bool allowView, bool allowFineTuning, string organization, object group, bool isBlocking)
+        public Permission(string id, string @object, int createdAtUnixTime, bool allowCreateEngine, bool allowSampling, bool allowLogprobs, bool allowSearchIndices, bool allowView, bool allowFineTuning, string organization, object group, bool isBlocking)
         {
             Id = id;
             Object = @object;
-            Created = created;
+            CreatedAtUnixTime = createdAtUnixTime;
             AllowCreateEngine = allowCreateEngine;
             AllowSampling = allowSampling;
             AllowLogprobs = allowLogprobs;
@@ -28,7 +29,10 @@ namespace OpenAI.Models
         public string Object { get; }
 
         [JsonPropertyName("created")]
-        public int Created { get; }
+        public int CreatedAtUnixTime { get; }
+
+        [JsonIgnore]
+        public DateTime CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnixTime).DateTime;
 
         [JsonPropertyName("allow_create_engine")]
         public bool AllowCreateEngine { get; }

--- a/OpenAI-DotNet/Moderations/ModerationsEndpoint.cs
+++ b/OpenAI-DotNet/Moderations/ModerationsEndpoint.cs
@@ -36,7 +36,7 @@ namespace OpenAI.Moderations
         /// </returns>
         public async Task<bool> GetModerationAsync(string input, Model model = null)
         {
-            var result = await CreateModerationAsync(new ModerationsRequest(input, model));
+            var result = await CreateModerationAsync(new ModerationsRequest(input, model)).ConfigureAwait(false);
 
             if (result?.Results == null ||
                 result.Results.Count == 0)
@@ -55,11 +55,11 @@ namespace OpenAI.Moderations
         public async Task<ModerationsResponse> CreateModerationAsync(ModerationsRequest request)
         {
             var jsonContent = JsonSerializer.Serialize(request, Api.JsonSerializationOptions);
-            var response = await Api.Client.PostAsync(GetEndpoint(), jsonContent.ToJsonStringContent());
+            var response = await Api.Client.PostAsync(GetEndpoint(), jsonContent.ToJsonStringContent()).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
             {
-                var resultAsString = await response.Content.ReadAsStringAsync();
+                var resultAsString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var moderationResponse = JsonSerializer.Deserialize<ModerationsResponse>(resultAsString, Api.JsonSerializationOptions);
 
                 if (moderationResponse == null)

--- a/OpenAI-DotNet/Moderations/ModerationsResponse.cs
+++ b/OpenAI-DotNet/Moderations/ModerationsResponse.cs
@@ -6,7 +6,7 @@ namespace OpenAI.Moderations
     public sealed class ModerationsResponse : BaseResponse
     {
         [JsonConstructor]
-        public ModerationsResponse(string id, string model, List<ModerationResult> results)
+        public ModerationsResponse(string id, string model, IReadOnlyList<ModerationResult> results)
         {
             Id = id;
             Model = model;
@@ -20,6 +20,6 @@ namespace OpenAI.Moderations
         public string Model { get; }
 
         [JsonPropertyName("results")]
-        public List<ModerationResult> Results { get; }
+        public IReadOnlyList<ModerationResult> Results { get; }
     }
 }

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -1,32 +1,39 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Stephen Hodgson</Authors>
     <Product>OpenAI-DotNet</Product>
-    <Description>A simple C# / .NET wrapper library to use with OpenAI's GPT-3 API (currently in beta).  Independently developed, this is not an official library and I am not affiliated with OpenAI.  An OpenAI API account is required.
-
-    Based on OpenAI-API by OKGoDoIt (Roger Pincombe)</Description>
+    <Description>A simple C# / .NET wrapper library to use with OpenAI's GPT-3 API (currently in beta).|
+Independently developed, this is not an official library and I am not affiliated with OpenAI.|
+An OpenAI API account is required.
+Based on OpenAI-API by OKGoDoIt (Roger Pincombe)</Description>
     <Copyright></Copyright>
     <PackageLicenseExpression>CC0-1.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/RageAgainstThePixel/OpenAI-DotNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/RageAgainstThePixel/OpenAI-DotNet</RepositoryUrl>
-    <PackageTags>OpenAI, AI, ML, API</PackageTags>
+    <PackageTags>OpenAI, AI, ML, API, gpt, gpt-3</PackageTags>
     <Title>OpenAI API</Title>
-    <PackageReleaseNotes>
-Bump version to 4.2.0
-Added missing Completions namespace.
-Alignment with com.openai.unity library.
-Misc formatting and bug fixes.
-    </PackageReleaseNotes>
+    <PackageReleaseNotes>Bump version to 4.3.0
+Fixed an issue when searching for .openai config file
+Renamed CreateFineTuneAsync -&gt; CreateFineTuneJobAsync
+Renamed CancelFineTuneJob -&gt; CancelFineTuneJobAsync
+Immutable response objects</PackageReleaseNotes>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
     <PackageId>OpenAI-DotNet</PackageId>
-    <Version>4.2.0</Version>
-    <AssemblyVersion>4.2.0.0</AssemblyVersion>
-    <FileVersion>4.2.0.0</FileVersion>
+    <Version>4.3.0</Version>
+    <AssemblyVersion>4.3.0.0</AssemblyVersion>
+    <FileVersion>4.3.0.0</FileVersion>
     <Company>RageAgainstThePixel</Company>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 </Project>

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -16,10 +16,15 @@ Based on OpenAI-API by OKGoDoIt (Roger Pincombe)</Description>
     <PackageTags>OpenAI, AI, ML, API, gpt, gpt-3</PackageTags>
     <Title>OpenAI API</Title>
     <PackageReleaseNotes>Bump version to 4.3.0
-Fixed an issue when searching for .openai config file
-Renamed CreateFineTuneAsync -&gt; CreateFineTuneJobAsync
-Renamed CancelFineTuneJob -&gt; CancelFineTuneJobAsync
-Immutable response objects</PackageReleaseNotes>
+- Fixed an issue when searching for .openai config file
+- Immutable response objects
+- Renamed `CreateFineTuneAsync` -&gt; `CreateFineTuneJobAsync`
+- Renamed `CancelFineTuneJob` -&gt; `CancelFineTuneJobAsync`
+- removed `OpenAI.Models.Permission.Created`
+- added `OpenAI.Models.Permission.CreatedAt`
+- added `OpenAI.Models.Permission.CreatedAtUnixTime`
+- `FineTuneJobResponse` is now internal but implicitly casted to `FineTuneJob`
+- Changed User-Agent of library to OpenAI-DotNet</PackageReleaseNotes>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Stephen Hodgson</Authors>

--- a/OpenAI-DotNet/OpenAIAuthentication.cs
+++ b/OpenAI-DotNet/OpenAIAuthentication.cs
@@ -74,7 +74,7 @@ namespace OpenAI
                 cachedDefault = auth ?? throw new UnauthorizedAccessException("Failed to load a valid API Key!");
                 return auth;
             }
-            set => cachedDefault = value;
+            internal set => cachedDefault = value;
         }
 
         /// <summary>
@@ -138,11 +138,13 @@ namespace OpenAI
 
             while (authInfo == null && currentDirectory.Parent != null)
             {
-                if (File.Exists(Path.Combine(currentDirectory.FullName, filename)))
+                var filePath = Path.Combine(currentDirectory.FullName, filename);
+
+                if (File.Exists(filePath))
                 {
                     try
                     {
-                        authInfo = JsonSerializer.Deserialize<AuthInfo>(File.ReadAllText(filename));
+                        authInfo = JsonSerializer.Deserialize<AuthInfo>(File.ReadAllText(filePath));
                         break;
                     }
                     catch (Exception)
@@ -150,7 +152,7 @@ namespace OpenAI
                         // try to parse the old way for backwards support.
                     }
 
-                    var lines = File.ReadAllLines(Path.Combine(currentDirectory.FullName, filename));
+                    var lines = File.ReadAllLines(filePath);
                     string apiKey = null;
                     string organization = null;
 

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -17,7 +17,7 @@ namespace OpenAI
     /// <summary>
     /// Entry point to the OpenAI API, handling auth and allowing access to the various API endpoints
     /// </summary>
-    public class OpenAIClient
+    public sealed class OpenAIClient
     {
         /// <summary>
         /// Creates a new entry point to the OpenAPI API, handling auth and allowing access to the various API endpoints

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -46,7 +46,7 @@ namespace OpenAI
             }
 
             Client = new HttpClient();
-            Client.DefaultRequestHeaders.Add("User-Agent", "dotnet_openai_api");
+            Client.DefaultRequestHeaders.Add("User-Agent", "OpenAI-DotNet");
             Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", OpenAIAuthentication.ApiKey);
 
             if (!string.IsNullOrWhiteSpace(OpenAIAuthentication.Organization))

--- a/OpenAI-DotNet/Usage.cs
+++ b/OpenAI-DotNet/Usage.cs
@@ -8,8 +8,7 @@ namespace OpenAI
         public Usage(
             int promptTokens,
             int completionTokens,
-            int totalTokens
-        )
+            int totalTokens)
         {
             PromptTokens = promptTokens;
             CompletionTokens = completionTokens;

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple C# .NET wrapper library to use with [OpenAI](https://openai.com/)'s GPT
 
 ## Requirements
 
-This library targets .NET 5.0 and above.
+This library targets .NET 6.0 and above.
 
 It should work across console apps, winforms, wpf, asp.net, etc.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple C# .NET wrapper library to use with [OpenAI](https://openai.com/)'s GPT
 
 ## Requirements
 
-This library is based on .NET 6.0.
+This library targets .NET 5.0 and above.
 
 It should work across console apps, winforms, wpf, asp.net, etc.
 
@@ -354,7 +354,7 @@ Response includes details of the enqueued job including job status and the name 
 ```csharp
 var api = new OpenAIClient();
 var request = new CreateFineTuneRequest(fileData);
-var fineTuneResponse = await api.FineTuningEndpoint.CreateFineTuneAsync(request);
+var fineTuneResponse = await api.FineTuningEndpoint.CreateFineTuneJobAsync(request);
 ```
 
 #### [List Fine Tune Jobs](https://beta.openai.com/docs/api-reference/fine-tunes/list)
@@ -381,7 +381,7 @@ Immediately cancel a fine-tune job.
 
 ```csharp
 var api = new OpenAIClient();
-var result = await api.FineTuningEndpoint.CancelFineTuneJob(job);
+var result = await api.FineTuningEndpoint.CancelFineTuneJobAsync(job);
 // result = true
 ```
 


### PR DESCRIPTION
- Fixed an issue when searching for .openai config file
- Immutable response objects
- Renamed `CreateFineTuneAsync` -> `CreateFineTuneJobAsync`
- Renamed `CancelFineTuneJob` -> `CancelFineTuneJobAsync`
- removed `OpenAI.Models.Permission.Created`
- added `OpenAI.Models.Permission.CreatedAt`
- added `OpenAI.Models.Permission.CreatedAtUnixTime`
- `FineTuneJobResponse` is now internal but implicitly casted to `FineTuneJob`
- Changed `User-Agent` of library to `OpenAI-DotNet`