### PR TITLE
OpenAI-DotNet 4.4.3

### DIFF
--- a/OpenAI-DotNet-Tests/OpenAI-DotNet-Tests.csproj
+++ b/OpenAI-DotNet-Tests/OpenAI-DotNet-Tests.csproj
@@ -5,6 +5,12 @@
     <SignAssembly>false</SignAssembly>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />

--- a/OpenAI-DotNet-Tests/TestFixture_00_Authentication.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_00_Authentication.cs
@@ -24,14 +24,14 @@ namespace OpenAI.Tests
             Assert.IsNotNull(auth);
             Assert.IsNotNull(auth.ApiKey);
             Assert.IsNotEmpty(auth.ApiKey);
-            Assert.IsNull(auth.Organization);
+            Assert.IsNull(auth.OrganizationId);
 
             auth = OpenAIAuthentication.LoadFromEnv("org-testOrg");
             Assert.IsNotNull(auth);
             Assert.IsNotNull(auth.ApiKey);
             Assert.IsNotEmpty(auth.ApiKey);
-            Assert.IsNotNull(auth.Organization);
-            Assert.IsNotEmpty(auth.Organization);
+            Assert.IsNotNull(auth.OrganizationId);
+            Assert.IsNotEmpty(auth.OrganizationId);
         }
 
         [Test]
@@ -41,8 +41,8 @@ namespace OpenAI.Tests
             Assert.IsNotNull(auth);
             Assert.IsNotNull(auth.ApiKey);
             Assert.AreEqual("sk-test12", auth.ApiKey);
-            Assert.IsNotNull(auth.Organization);
-            Assert.AreEqual("org-testOrg", auth.Organization);
+            Assert.IsNotNull(auth.OrganizationId);
+            Assert.AreEqual("org-testOrg", auth.OrganizationId);
         }
 
         [Test]
@@ -59,8 +59,8 @@ namespace OpenAI.Tests
             Assert.IsNotNull(auth);
             Assert.IsNotNull(auth.ApiKey);
             Assert.AreEqual("sk-test12", auth.ApiKey);
-            Assert.IsNotNull(auth.Organization);
-            Assert.AreEqual("org-testOrg", auth.Organization);
+            Assert.IsNotNull(auth.OrganizationId);
+            Assert.AreEqual("org-testOrg", auth.OrganizationId);
         }
 
         [Test]
@@ -72,18 +72,18 @@ namespace OpenAI.Tests
             var shouldBeDefaultAuth = api.OpenAIAuthentication;
             Assert.IsNotNull(shouldBeDefaultAuth);
             Assert.IsNotNull(shouldBeDefaultAuth.ApiKey);
-            Assert.IsNotNull(shouldBeDefaultAuth.Organization);
+            Assert.IsNotNull(shouldBeDefaultAuth.OrganizationId);
             Assert.AreEqual(defaultAuth.ApiKey, shouldBeDefaultAuth.ApiKey);
-            Assert.AreEqual(defaultAuth.Organization, shouldBeDefaultAuth.Organization);
+            Assert.AreEqual(defaultAuth.OrganizationId, shouldBeDefaultAuth.OrganizationId);
 
             OpenAIAuthentication.Default = new OpenAIAuthentication("sk-testAA", "org-testAA");
             api = new OpenAIClient();
             var shouldBeManualAuth = api.OpenAIAuthentication;
             Assert.IsNotNull(shouldBeManualAuth);
             Assert.IsNotNull(shouldBeManualAuth.ApiKey);
-            Assert.IsNotNull(shouldBeManualAuth.Organization);
+            Assert.IsNotNull(shouldBeManualAuth.OrganizationId);
             Assert.AreEqual(manualAuth.ApiKey, shouldBeManualAuth.ApiKey);
-            Assert.AreEqual(manualAuth.Organization, shouldBeManualAuth.Organization);
+            Assert.AreEqual(manualAuth.OrganizationId, shouldBeManualAuth.OrganizationId);
 
             OpenAIAuthentication.Default = defaultAuth;
         }
@@ -134,8 +134,8 @@ namespace OpenAI.Tests
         public void Test_09_GetOrganization()
         {
             var auth = new OpenAIAuthentication("sk-testAA", "org-testAA");
-            Assert.IsNotNull(auth.Organization);
-            Assert.AreEqual("org-testAA", auth.Organization);
+            Assert.IsNotNull(auth.OrganizationId);
+            Assert.AreEqual("org-testAA", auth.OrganizationId);
         }
 
         [Test]

--- a/OpenAI-DotNet-Tests/TestFixture_07_FineTunes.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_07_FineTunes.cs
@@ -203,7 +203,7 @@ namespace OpenAI.Tests
 
             foreach (var model in models)
             {
-                if (model.OwnedBy == api.OpenAIAuthentication.Organization)
+                if (model.OwnedBy == api.OpenAIAuthentication.OrganizationId)
                 {
                     Console.WriteLine(model);
                     var result = await api.ModelsEndpoint.DeleteFineTuneModelAsync(model);

--- a/OpenAI-DotNet/AuthInfo.cs
+++ b/OpenAI-DotNet/AuthInfo.cs
@@ -6,7 +6,7 @@ namespace OpenAI
     internal class AuthInfo
     {
         [JsonConstructor]
-        public AuthInfo(string apiKey, string organization = null)
+        public AuthInfo(string apiKey, string organizationId = null)
         {
             if (!apiKey.Contains("sk-"))
             {
@@ -15,14 +15,14 @@ namespace OpenAI
 
             ApiKey = apiKey;
 
-            if (organization != null)
+            if (organizationId != null)
             {
-                if (!organization.Contains("org-"))
+                if (!organizationId.Contains("org-"))
                 {
-                    throw new InvalidCredentialException($"{nameof(organization)} parameter must start with 'org-'");
+                    throw new InvalidCredentialException($"{nameof(organizationId)} parameter must start with 'org-'");
                 }
 
-                Organization = organization;
+                OrganizationId = organizationId;
             }
         }
 
@@ -30,6 +30,6 @@ namespace OpenAI
         public string ApiKey { get; }
 
         [JsonPropertyName("organization")]
-        public string Organization { get; }
+        public string OrganizationId { get; }
     }
 }

--- a/OpenAI-DotNet/Models/ModelsEndpoint.cs
+++ b/OpenAI-DotNet/Models/ModelsEndpoint.cs
@@ -87,7 +87,7 @@ namespace OpenAI.Models
                 throw new Exception($"Failed to get {modelId} info!");
             }
 
-            if (model.OwnedBy != Api.OpenAIAuthentication.Organization)
+            if (model.OwnedBy != Api.OpenAIAuthentication.OrganizationId)
             {
                 throw new UnauthorizedAccessException($"{model.Id} is not owned by your organization.");
             }

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -34,11 +34,17 @@ Bump version to 4.4.2
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
     <PackageId>OpenAI-DotNet</PackageId>
-    <Version>4.4.2</Version>
-    <AssemblyVersion>4.4.2.0</AssemblyVersion>
-    <FileVersion>4.4.2.0</FileVersion>
+    <Version>4.4.3</Version>
+    <AssemblyVersion>4.4.3.0</AssemblyVersion>
+    <FileVersion>4.4.3.0</FileVersion>
     <Company>RageAgainstThePixel</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\README.md">

--- a/OpenAI-DotNet/OpenAIAuthentication.cs
+++ b/OpenAI-DotNet/OpenAIAuthentication.cs
@@ -13,6 +13,7 @@ namespace OpenAI
         private const string OPENAI_API_KEY = "OPENAI_API_KEY";
         private const string OPENAI_SECRET_KEY = "OPENAI_SECRET_KEY";
         private const string TEST_OPENAI_SECRET_KEY = "TEST_OPENAI_SECRET_KEY";
+        private const string OPEN_AI_ORGANIZATION_ID = "OPEN_AI_ORGANIZATION_ID";
         private const string ORGANIZATION = "ORGANIZATION";
 
         private readonly AuthInfo authInfo;
@@ -22,11 +23,14 @@ namespace OpenAI
         /// </summary>
         public string ApiKey => authInfo.ApiKey;
 
+        [Obsolete("Use OrganizationId instead")]
+        public string Organization => authInfo.OrganizationId;
+
         /// <summary>
         /// For users who belong to multiple organizations, you can pass a header to specify which organization is used for an API request.
         /// Usage from these API requests will count against the specified organization's subscription quota.
         /// </summary>
-        public string Organization => authInfo.Organization;
+        public string OrganizationId => authInfo.OrganizationId;
 
         /// <summary>
         /// Allows implicit casting from a string, so that a simple string API key can be provided in place of an instance of <see cref="OpenAIAuthentication"/>.
@@ -80,7 +84,7 @@ namespace OpenAI
         /// <summary>
         /// Attempts to load api keys from environment variables, as "OPENAI_KEY" (or "OPENAI_SECRET_KEY", for backwards compatibility)
         /// </summary>
-        /// <param name="organization">
+        /// <param name="organizationId">
         /// For users who belong to multiple organizations, you can pass a header to specify which organization is used for an API request.
         /// Usage from these API requests will count against the specified organization's subscription quota.
         /// </param>
@@ -88,7 +92,7 @@ namespace OpenAI
         /// Returns the loaded <see cref="OpenAIAuthentication"/> any api keys were found,
         /// or <see langword="null"/> if there were no matching environment vars.
         /// </returns>
-        public static OpenAIAuthentication LoadFromEnv(string organization = null)
+        public static OpenAIAuthentication LoadFromEnv(string organizationId = null)
         {
             var apiKey = Environment.GetEnvironmentVariable(OPENAI_KEY);
 
@@ -107,7 +111,12 @@ namespace OpenAI
                 apiKey = Environment.GetEnvironmentVariable(TEST_OPENAI_SECRET_KEY);
             }
 
-            return string.IsNullOrEmpty(apiKey) ? null : new OpenAIAuthentication(apiKey, organization);
+            if (string.IsNullOrWhiteSpace(organizationId))
+            {
+                organizationId = Environment.GetEnvironmentVariable(OPEN_AI_ORGANIZATION_ID);
+            }
+
+            return string.IsNullOrEmpty(apiKey) ? null : new OpenAIAuthentication(apiKey, organizationId);
         }
 
         /// <summary>

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -49,9 +49,9 @@ namespace OpenAI
             Client.DefaultRequestHeaders.Add("User-Agent", "OpenAI-DotNet");
             Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", OpenAIAuthentication.ApiKey);
 
-            if (!string.IsNullOrWhiteSpace(OpenAIAuthentication.Organization))
+            if (!string.IsNullOrWhiteSpace(OpenAIAuthentication.OrganizationId))
             {
-                Client.DefaultRequestHeaders.Add("OpenAI-Organization", OpenAIAuthentication.Organization);
+                Client.DefaultRequestHeaders.Add("OpenAI-Organization", OpenAIAuthentication.OrganizationId);
             }
 
             Version = 1;

--- a/README.md
+++ b/README.md
@@ -119,10 +119,19 @@ var api = new OpenAIClient(OpenAIAuthentication.LoadFromDirectory("your/path/to/
 
 #### Use System Environment Variables
 
-> Use `OPENAI_KEY` or `OPENAI_SECRET_KEY` specify a key defined in the system's local environment:
+Use your system's environment variables specify an api key and organization to use.
+
+- Use `OPENAI_API_KEY` for your api key.
+- Use `OPEN_AI_ORGANIZATION_ID` to specify an organization.
 
 ```csharp
 var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
+```
+
+or
+
+```csharp
+var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv("org-yourOrganizationId"));
 ```
 
 ### [Models](https://beta.openai.com/docs/api-reference/models)


### PR DESCRIPTION
- added `OPEN_AI_ORGANIZATION_ID` environment variable
- deprecated `Organization` use `OrganizationId` instead