### PR TITLE
OpenAI-DotNet 4.4.4

### DIFF
--- a/OpenAI-DotNet/AuthInfo.cs
+++ b/OpenAI-DotNet/AuthInfo.cs
@@ -8,18 +8,19 @@ namespace OpenAI
         [JsonConstructor]
         public AuthInfo(string apiKey, string organizationId = null)
         {
-            if (!apiKey.Contains("sk-"))
+            if (string.IsNullOrWhiteSpace(apiKey) ||
+                !apiKey.Contains("sk-"))
             {
-                throw new InvalidCredentialException($"{apiKey} parameter must start with 'sk-'");
+                throw new InvalidCredentialException($"{apiKey} must start with 'sk-'");
             }
 
             ApiKey = apiKey;
 
-            if (organizationId != null)
+            if (!string.IsNullOrWhiteSpace(organizationId))
             {
                 if (!organizationId.Contains("org-"))
                 {
-                    throw new InvalidCredentialException($"{nameof(organizationId)} parameter must start with 'org-'");
+                    throw new InvalidCredentialException($"{nameof(organizationId)} must start with 'org-'");
                 }
 
                 OrganizationId = organizationId;

--- a/OpenAI-DotNet/Images/ImageEditRequest.cs
+++ b/OpenAI-DotNet/Images/ImageEditRequest.cs
@@ -29,46 +29,16 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         public ImageEditRequest(string imagePath, string maskPath, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+            : this(
+                File.OpenRead(imagePath),
+                Path.GetFileName(imagePath),
+                string.IsNullOrWhiteSpace(maskPath) ? null : File.OpenRead(maskPath),
+                string.IsNullOrWhiteSpace(maskPath) ? null : Path.GetFileName(maskPath),
+                prompt,
+                numberOfResults,
+                size,
+                user)
         {
-            if (!File.Exists(imagePath))
-            {
-                throw new FileNotFoundException($"Could not find the {nameof(imagePath)} file located at {imagePath}");
-            }
-
-            Image = File.OpenRead(imagePath);
-            ImageName = Path.GetFileName(imagePath);
-
-            if (!File.Exists(maskPath))
-            {
-                throw new FileNotFoundException($"Could not find the {nameof(maskPath)} file located at {maskPath}");
-            }
-
-            Mask = File.OpenRead(maskPath);
-            MaskName = Path.GetFileName(maskPath);
-
-            if (prompt.Length > 1000)
-            {
-                throw new ArgumentOutOfRangeException(nameof(prompt), "The maximum character length for the prompt is 1000 characters.");
-            }
-
-            Prompt = prompt;
-
-            if (numberOfResults is > 10 or < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(numberOfResults), "The number of results must be between 1 and 10");
-            }
-
-            Number = numberOfResults;
-
-            Size = size switch
-            {
-                ImageSize.Small => "256x256",
-                ImageSize.Medium => "512x512",
-                ImageSize.Large => "1024x1024",
-                _ => throw new ArgumentOutOfRangeException(nameof(size), size, null)
-            };
-
-            User = user;
         }
 
         /// <summary>
@@ -99,9 +69,25 @@ namespace OpenAI.Images
         public ImageEditRequest(Stream image, string imageName, Stream mask, string maskName, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
         {
             Image = image;
+
+            if (string.IsNullOrWhiteSpace(imageName))
+            {
+                imageName = "image.png";
+            }
+
             ImageName = imageName;
-            Mask = mask;
-            MaskName = maskName;
+
+            if (mask != null)
+            {
+                Mask = mask;
+
+                if (string.IsNullOrWhiteSpace(maskName))
+                {
+                    maskName = "mask.png";
+                }
+
+                MaskName = maskName;
+            }
 
             if (prompt.Length > 1000)
             {

--- a/OpenAI-DotNet/Images/ImageVariationRequest.cs
+++ b/OpenAI-DotNet/Images/ImageVariationRequest.cs
@@ -10,7 +10,6 @@ namespace OpenAI.Images
         /// </summary>
         /// <param name="imagePath">
         /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
-        /// If mask is not provided, image must have transparency, which will be used as the mask.
         /// </param>
         /// <param name="numberOfResults">
         /// The number of images to generate. Must be between 1 and 10.
@@ -22,14 +21,38 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         public ImageVariationRequest(string imagePath, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+            : this(File.OpenRead(imagePath), Path.GetFileName(imagePath), numberOfResults, size, user)
         {
-            if (!File.Exists(imagePath))
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="image">
+        /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
+        /// </param>
+        /// <param name="imageName">
+        /// The name of the image.
+        /// </param>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        public ImageVariationRequest(Stream image, string imageName, int numberOfResults, ImageSize size, string user)
+        {
+            Image = image;
+
+            if (string.IsNullOrWhiteSpace(imageName))
             {
-                throw new FileNotFoundException($"Could not find the {nameof(imagePath)} file located at {imagePath}");
+                imageName = "image.png";
             }
 
-            Image = File.OpenRead(imagePath);
-            ImageName = Path.GetFileName(imagePath);
+            ImageName = imageName;
 
             if (numberOfResults is > 10 or < 1)
             {

--- a/OpenAI-DotNet/Images/ImagesEndpoint.cs
+++ b/OpenAI-DotNet/Images/ImagesEndpoint.cs
@@ -86,9 +86,14 @@ namespace OpenAI.Images
             using var imageData = new MemoryStream();
             await request.Image.CopyToAsync(imageData, cancellationToken).ConfigureAwait(false);
             content.Add(new ByteArrayContent(imageData.ToArray()), "image", request.ImageName);
-            using var maskData = new MemoryStream();
-            await request.Mask.CopyToAsync(maskData, cancellationToken).ConfigureAwait(false);
-            content.Add(new ByteArrayContent(maskData.ToArray()), "mask", request.MaskName);
+
+            if (request.Mask != null)
+            {
+                using var maskData = new MemoryStream();
+                await request.Mask.CopyToAsync(maskData, cancellationToken);
+                content.Add(new ByteArrayContent(maskData.ToArray()), "mask", request.MaskName);
+            }
+
             content.Add(new StringContent(request.Prompt), "prompt");
             content.Add(new StringContent(request.Number.ToString()), "n");
             content.Add(new StringContent(request.Size), "size");

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -15,7 +15,20 @@ Based on OpenAI-API by OKGoDoIt (Roger Pincombe)</Description>
     <RepositoryUrl>https://github.com/RageAgainstThePixel/OpenAI-DotNet</RepositoryUrl>
     <PackageTags>OpenAI, AI, ML, API, gpt, gpt-3, chatGPT</PackageTags>
     <Title>OpenAI API</Title>
-    <PackageReleaseNotes>Bump version to 4.4.0
+    <PackageReleaseNotes>Bump version to 4.4.4
+- ImageEditRequest mask is now optional so long as texture has alpha transparency
+- Updated AuthInfo parameter validation
+- Renamed OPEN_AI_ORGANIZATION_ID -&gt; OPENAI_ORGANIZATION_ID
+Bump version to 4.4.3
+- added `OPEN_AI_ORGANIZATION_ID` environment variable
+- deprecated `Organization` use `OrganizationId` instead
+Bump version to 4.4.2
+- Removed a useless assert
+- Updated docs
+Bump version to 4.4.1
+- hotfix to CompletionsEndpoint to use `IEnumerable&lt;string&gt;`
+- hotfix to cleanup Images endpoints
+Bump version to 4.4.0
 - Renamed `Choice.Logprobs -&gt; Choice.LogProbabilities`
 - Renamed `OpenAI.Completions.Logprobs -&gt; OpenAI.Completions.OpenAI.Completions`
 - Renamed `CompletionRequest` parameter names:
@@ -23,20 +36,14 @@ Based on OpenAI-API by OKGoDoIt (Roger Pincombe)</Description>
   - `top_p` -&gt; `topP`
 - Updated `CompletionRequest` to accept `IEnumerable&lt;string&gt;` values for `prompts` and `stopSequences`
 - Refactored all endpoints to use new response validation extension
-- Added `CancellationToken` to most endpoints that had long running operations
-Bump version to 4.4.1
-- hotfix to CompletionsEndpoint to use `IEnumerable&lt;string&gt;`
-- hotfix to cleanup Images endpoints
-Bump version to 4.4.2
-- Removed a useless assert
-- Updated docs</PackageReleaseNotes>
+- Added `CancellationToken` to most endpoints that had long running operations</PackageReleaseNotes>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
     <PackageId>OpenAI-DotNet</PackageId>
-    <Version>4.4.3</Version>
-    <AssemblyVersion>4.4.3.0</AssemblyVersion>
-    <FileVersion>4.4.3.0</FileVersion>
+    <Version>4.4.4</Version>
+    <AssemblyVersion>4.4.4.0</AssemblyVersion>
+    <FileVersion>4.4.4.0</FileVersion>
     <Company>RageAgainstThePixel</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -17,6 +17,7 @@ Based on OpenAI-API by OKGoDoIt (Roger Pincombe)</Description>
     <Title>OpenAI API</Title>
     <PackageReleaseNotes>Bump version to 4.4.4
 - ImageEditRequest mask is now optional so long as texture has alpha transparency
+- ImageVariationRequest added constructor overload for memory stream image 
 - Updated AuthInfo parameter validation
 - Renamed OPEN_AI_ORGANIZATION_ID -&gt; OPENAI_ORGANIZATION_ID
 Bump version to 4.4.3

--- a/OpenAI-DotNet/OpenAIAuthentication.cs
+++ b/OpenAI-DotNet/OpenAIAuthentication.cs
@@ -13,6 +13,7 @@ namespace OpenAI
         private const string OPENAI_API_KEY = "OPENAI_API_KEY";
         private const string OPENAI_SECRET_KEY = "OPENAI_SECRET_KEY";
         private const string TEST_OPENAI_SECRET_KEY = "TEST_OPENAI_SECRET_KEY";
+        private const string OPENAI_ORGANIZATION_ID = "OPENAI_ORGANIZATION_ID";
         private const string OPEN_AI_ORGANIZATION_ID = "OPEN_AI_ORGANIZATION_ID";
         private const string ORGANIZATION = "ORGANIZATION";
 
@@ -114,6 +115,11 @@ namespace OpenAI
             if (string.IsNullOrWhiteSpace(organizationId))
             {
                 organizationId = Environment.GetEnvironmentVariable(OPEN_AI_ORGANIZATION_ID);
+            }
+
+            if (string.IsNullOrWhiteSpace(organizationId))
+            {
+                organizationId = Environment.GetEnvironmentVariable(OPENAI_ORGANIZATION_ID);
             }
 
             return string.IsNullOrEmpty(apiKey) ? null : new OpenAIAuthentication(apiKey, organizationId);

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ You use the `OpenAIAuthentication` when you initialize the API as shown:
 #### Pass keys directly with constructor
 
 ```csharp
-var api = new OpenAIClient("sk-mykeyhere");
+var api = new OpenAIClient("sk-apiKey");
 ```
 
 Or create a `OpenAIAuthentication` object manually
 
 ```csharp
-var api = new OpenAIClient(new OpenAIAuthentication("sk-secretkey"));
+var api = new OpenAIClient(new OpenAIAuthentication("sk-apiKey", "org-yourOrganizationId"));
 ```
 
 #### Load key from configuration file
@@ -122,16 +122,10 @@ var api = new OpenAIClient(OpenAIAuthentication.LoadFromDirectory("your/path/to/
 Use your system's environment variables specify an api key and organization to use.
 
 - Use `OPENAI_API_KEY` for your api key.
-- Use `OPEN_AI_ORGANIZATION_ID` to specify an organization.
+- Use `OPENAI_ORGANIZATION_ID` to specify an organization.
 
 ```csharp
 var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
-```
-
-or
-
-```csharp
-var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv("org-yourOrganizationId"));
 ```
 
 ### [Models](https://beta.openai.com/docs/api-reference/models)


### PR DESCRIPTION
- `ImageEditRequest` mask is now optional so long as texture has alpha transparency
- `ImageVariationRequest` added constructor overload for memory stream image 
- Updated `AuthInfo` parameter validation
- Renamed `OPEN_AI_ORGANIZATION_ID` -> `OPENAI_ORGANIZATION_ID`
- Updated docs