### PR TITLE
Allows fine tuned models to be deleted

### DIFF
--- a/OpenAI-DotNet-Tests/TestFixture_09_FineTuning.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_09_FineTuning.cs
@@ -4,6 +4,7 @@ using OpenAI.FineTuning;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -201,16 +202,13 @@ namespace OpenAI.Tests
             Assert.IsNotNull(models);
             Assert.IsNotEmpty(models);
 
-            foreach (var model in models)
+            foreach (var model in models.Where(x => x.OwnedBy.StartsWith("user-")))
             {
-                if (model.OwnedBy == api.OpenAIAuthentication.OrganizationId)
-                {
-                    Console.WriteLine(model);
-                    var result = await api.ModelsEndpoint.DeleteFineTuneModelAsync(model);
-                    Assert.IsNotNull(result);
-                    Assert.IsTrue(result);
-                    Console.WriteLine($"{model.Id} -> deleted");
-                }
+                Console.WriteLine(model);
+                var result = await api.ModelsEndpoint.DeleteFineTuneModelAsync(model);
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result);
+                Console.WriteLine($"{model.Id} -> deleted");
             }
         }
     }

--- a/OpenAI-DotNet/Models/ModelsEndpoint.cs
+++ b/OpenAI-DotNet/Models/ModelsEndpoint.cs
@@ -87,11 +87,6 @@ namespace OpenAI.Models
                 throw new Exception($"Failed to get {modelId} info!");
             }
 
-            if (model.OwnedBy != Api.OpenAIAuthentication.OrganizationId)
-            {
-                throw new UnauthorizedAccessException($"{model.Id} is not owned by your organization.");
-            }
-
             var response = await Api.Client.DeleteAsync($"{GetEndpoint()}/{model.Id}").ConfigureAwait(false);
             var responseAsString = await response.ReadAsStringAsync().ConfigureAwait(false);
             return JsonSerializer.Deserialize<DeleteModelResponse>(responseAsString, Api.JsonSerializationOptions)?.Deleted ?? false;


### PR DESCRIPTION
This allows a **FineTuned** module to be deleted (right now it cannot)

The checks for model ownership cannot be used because the model endpoint indicates that a model belongs to "user-" but, it actually belongs to the organization and can be deleted. 

For more information see this forum post in the OpenAI forum:
https://community.openai.com/t/i-cannot-delete-a-finetuned-model-that-i-created/93018

![6debc33d73d0e8acc1870e12668ac4e4005a23e4_2_658x750](https://user-images.githubusercontent.com/1857799/224404970-600e5c02-5908-4c83-aee1-2ac1de01e160.png)
