### PR TITLE
OpenAI-DotNet 6.3.1

### DIFF
--- a/.github/workflows/Publish-Nuget.yml
+++ b/.github/workflows/Publish-Nuget.yml
@@ -37,6 +37,7 @@ jobs:
 
     - name: Test Packages
       run: dotnet test --configuration Release
+      if: ${{ github.ref != 'refs/heads/main' && github.event_name != 'push' }}
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         OPENAI_ORGANIZATION_ID: ${{ secrets.OPENAI_ORGANIZATION_ID }}

--- a/OpenAI-DotNet-Tests/TestFixture_00_Authentication.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_00_Authentication.cs
@@ -159,7 +159,7 @@ namespace OpenAI.Tests
         [Test]
         public void Test_11_AzureConfigurationSettings()
         {
-            var auth = new OpenAIAuthentication("sk-testAA", "org-testAA");
+            var auth = new OpenAIAuthentication("testKeyAaBbCcDd");
             var settings = new OpenAIClientSettings(resourceName: "test-resource", deploymentId: "deployment-id-test");
             var api = new OpenAIClient(auth, settings);
             Console.WriteLine(api.OpenAIClientSettings.BaseRequest);
@@ -169,7 +169,7 @@ namespace OpenAI.Tests
         [Test]
         public void Test_12_CustomDomainConfigurationSettings()
         {
-            var auth = new OpenAIAuthentication("sess-customToken");
+            var auth = new OpenAIAuthentication("sess-customIssuedToken");
             var settings = new OpenAIClientSettings(domain: "api.your-custom-domain.com");
             var api = new OpenAIClient(auth, settings);
             Console.WriteLine(api.OpenAIClientSettings.BaseRequest);

--- a/OpenAI-DotNet/AuthInfo.cs
+++ b/OpenAI-DotNet/AuthInfo.cs
@@ -5,20 +5,13 @@ namespace OpenAI
 {
     internal class AuthInfo
     {
-        private const string SecretKeyPrefix = "sk-";
-        private const string SessionKeyPrefix = "sess-";
-        private const string OrganizationPrefix = "org-";
+        internal const string SecretKeyPrefix = "sk-";
+        internal const string SessionKeyPrefix = "sess-";
+        internal const string OrganizationPrefix = "org-";
 
         [JsonConstructor]
         public AuthInfo(string apiKey, string organizationId = null)
         {
-            if (string.IsNullOrWhiteSpace(apiKey) ||
-                (!apiKey.Contains(SecretKeyPrefix) &&
-                 !apiKey.Contains(SessionKeyPrefix)))
-            {
-                throw new InvalidCredentialException($"{apiKey} must start with '{SecretKeyPrefix}'");
-            }
-
             ApiKey = apiKey;
 
             if (!string.IsNullOrWhiteSpace(organizationId))

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -17,7 +17,9 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <RepositoryUrl>https://github.com/RageAgainstThePixel/OpenAI-DotNet</RepositoryUrl>
     <PackageTags>OpenAI, AI, ML, API, gpt-4, gpt-3.5-tubo, gpt-3, chatGPT, chat-gpt, gpt-2, gpt</PackageTags>
     <Title>OpenAI API</Title>
-    <PackageReleaseNotes>Bump version to 6.3.0
+    <PackageReleaseNotes>Bump version to 6.3.1
+- Fixed apikey requiring sk- prefix with Azure OpenAI
+Bump version to 6.3.0
 - Removed OpenAI-DotNet-Proxy and put it directly in packge on its own
 Bump version to 6.2.0
 - Added OpenAI-DotNet-Proxy project and package.
@@ -77,7 +79,7 @@ Bump version to 4.4.0
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
     <PackageId>OpenAI-DotNet</PackageId>
-    <Version>6.3.0</Version>
+    <Version>6.3.1</Version>
     <Company>RageAgainstThePixel</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>Assets\OpenAI-DotNet-Icon.png</PackageIcon>

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -76,6 +76,13 @@ namespace OpenAI
 
             if (!OpenAIClientSettings.BaseRequestUrlFormat.Contains(OpenAIClientSettings.AzureOpenAIDomain))
             {
+                if (string.IsNullOrWhiteSpace(OpenAIAuthentication.ApiKey) ||
+                    (!OpenAIAuthentication.ApiKey.Contains(AuthInfo.SecretKeyPrefix) &&
+                     !OpenAIAuthentication.ApiKey.Contains(AuthInfo.SessionKeyPrefix)))
+                {
+                    throw new InvalidCredentialException($"{OpenAIAuthentication.ApiKey} must start with '{AuthInfo.SecretKeyPrefix}'");
+                }
+
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", OpenAIAuthentication.ApiKey);
             }
             else


### PR DESCRIPTION
- Fixes #49 apikey requiring sk- prefix with Azure OpenAI