### PR TITLE
HttpRequestException fix on different character sets

### DIFF
--- a/OpenAI-DotNet/Proxy/OpenAIProxyStartup.cs
+++ b/OpenAI-DotNet/Proxy/OpenAIProxyStartup.cs
@@ -103,11 +103,16 @@ namespace OpenAI.Proxy
 
                 foreach (var header in proxyResponse.Headers)
                 {
+                    // transfer encoding (and specifically 'chunked') occurs when different character sets are used - for example, latin and greek
+                    // the client doesn't know how to handle it, and crashes
+                    // when removed, it works just fine ..
+                    if (header.Key == "Transfer-Encoding") continue;
                     httpContext.Response.Headers[header.Key] = header.Value.ToArray();
                 }
 
                 foreach (var header in proxyResponse.Content.Headers)
                 {
+                    if (header.Key == "Transfer-Encoding") continue;
                     httpContext.Response.Headers[header.Key] = header.Value.ToArray();
                 }
 


### PR DESCRIPTION
- #57  

After digging around, it appears that this is common for proxies. The `Transfer-Encoding` header gets added, set to `chunked`, which throws the client off. 

It functions when the header is removed. 

Note: it appears to have no side effects, but I have only tested casually.