### PR TITLE
OpenAI-DotNet 6.4.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <OpenAIDotNetVersion>6.4.0</OpenAIDotNetVersion>
+    <OpenAIDotNetVersion>6.4.1</OpenAIDotNetVersion>
   </PropertyGroup>
 </Project>

--- a/OpenAI-DotNet/Images/ImageEditRequest.cs
+++ b/OpenAI-DotNet/Images/ImageEditRequest.cs
@@ -12,6 +12,30 @@ namespace OpenAI.Images
         /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
         /// If mask is not provided, image must have transparency, which will be used as the mask.
         /// </param>
+        /// <param name="prompt">
+        /// A text description of the desired image(s). The maximum length is 1000 characters.
+        /// </param>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        public ImageEditRequest(string imagePath, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+            : this(imagePath, null, prompt, numberOfResults, size, user)
+        {
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="imagePath">
+        /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
+        /// If mask is not provided, image must have transparency, which will be used as the mask.
+        /// </param>
         /// <param name="maskPath">
         /// An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where image should be edited.
         /// Must be a valid PNG file, less than 4MB, and have the same dimensions as image.
@@ -38,6 +62,31 @@ namespace OpenAI.Images
                 numberOfResults,
                 size,
                 user)
+        {
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="image">
+        /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
+        /// If mask is not provided, image must have transparency, which will be used as the mask.
+        /// </param>
+        /// <param name="imageName">Name of the image file.</param>
+        /// <param name="prompt">
+        /// A text description of the desired image(s). The maximum length is 1000 characters.
+        /// </param>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        public ImageEditRequest(Stream image, string imageName, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+            : this(image, imageName, null, null, prompt, numberOfResults, size, user)
         {
         }
 

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -17,7 +17,9 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <RepositoryUrl>https://github.com/RageAgainstThePixel/OpenAI-DotNet</RepositoryUrl>
     <PackageTags>OpenAI, AI, ML, API, gpt-4, gpt-3.5-tubo, gpt-3, chatGPT, chat-gpt, gpt-2, gpt</PackageTags>
     <Title>OpenAI API</Title>
-    <PackageReleaseNotes>Bump version to 6.4.0
+    <PackageReleaseNotes>Bump version to 6.4.1
+- Added ImageEditRequest overloads for optional mask parameter
+Bump version to 6.4.0
 - Moved OpenAI-DotNet-Proxy back into its own project and package
 - Make a few classes sealed that are not meant to be extended
 Bump version to 6.3.2


### PR DESCRIPTION
- Fixes #64
- Added `ImageEditRequest` overloads for optional mask parameter