### PR TITLE
OpenAI-DotNet 6.6.0

### DIFF
--- a/OpenAI-DotNet-Tests/TestFixture_05_Images.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_05_Images.cs
@@ -2,6 +2,7 @@
 using OpenAI.Images;
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace OpenAI.Tests
@@ -13,10 +14,11 @@ namespace OpenAI.Tests
         {
             Assert.IsNotNull(OpenAIClient.ImagesEndPoint);
 
-            var results = await OpenAIClient.ImagesEndPoint.GenerateImageAsync("A house riding a velociraptor", 1, ImageSize.Small);
+            var results = await OpenAIClient.ImagesEndPoint.GenerateImageAsync("A house riding a velociraptor", 1, ImageSize.Small, responseFormat: "b64_json");
 
             Assert.IsNotNull(results);
             Assert.NotZero(results.Count);
+            Assert.IsNotEmpty(results.First());
 
             foreach (var result in results)
             {

--- a/OpenAI-DotNet-Tests/TestFixture_05_Images.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_05_Images.cs
@@ -2,7 +2,6 @@
 using OpenAI.Images;
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace OpenAI.Tests
@@ -14,11 +13,11 @@ namespace OpenAI.Tests
         {
             Assert.IsNotNull(OpenAIClient.ImagesEndPoint);
 
-            var results = await OpenAIClient.ImagesEndPoint.GenerateImageAsync("A house riding a velociraptor", 1, ImageSize.Small, responseFormat: "b64_json");
+            var results = await OpenAIClient.ImagesEndPoint.GenerateImageAsync("A house riding a velociraptor", 1, ImageSize.Small);
 
             Assert.IsNotNull(results);
             Assert.NotZero(results.Count);
-            Assert.IsNotEmpty(results.First());
+            Assert.IsNotEmpty(results[0]);
 
             foreach (var result in results)
             {
@@ -27,7 +26,24 @@ namespace OpenAI.Tests
         }
 
         [Test]
-        public async Task Test_2_GenerateImageEdits()
+        public async Task Test_2_GenerateImages_B64_Json()
+        {
+            Assert.IsNotNull(OpenAIClient.ImagesEndPoint);
+
+            var results = await OpenAIClient.ImagesEndPoint.GenerateImageAsync("A house riding a velociraptor", 1, ImageSize.Small, responseFormat: ResponseFormat.B64_Json);
+
+            Assert.IsNotNull(results);
+            Assert.NotZero(results.Count);
+            Assert.IsNotEmpty(results[0]);
+
+            foreach (var result in results)
+            {
+                Console.WriteLine(result);
+            }
+        }
+
+        [Test]
+        public async Task Test_3_GenerateImageEdits()
         {
             Assert.IsNotNull(OpenAIClient.ImagesEndPoint);
 
@@ -46,13 +62,50 @@ namespace OpenAI.Tests
         }
 
         [Test]
-        public async Task Test_3_GenerateImageVariations()
+        public async Task Test_4_GenerateImageEdits_B64_Json()
+        {
+            Assert.IsNotNull(OpenAIClient.ImagesEndPoint);
+
+            var imageAssetPath = Path.GetFullPath("..\\..\\..\\Assets\\image_edit_original.png");
+            var maskAssetPath = Path.GetFullPath("..\\..\\..\\Assets\\image_edit_mask.png");
+
+            var results = await OpenAIClient.ImagesEndPoint.CreateImageEditAsync(imageAssetPath, maskAssetPath, "A sunlit indoor lounge area with a pool containing a flamingo", 1, ImageSize.Small);
+
+            Assert.IsNotNull(results);
+            Assert.NotZero(results.Count);
+
+            foreach (var result in results)
+            {
+                Console.WriteLine(result);
+            }
+        }
+
+        [Test]
+        public async Task Test_5_GenerateImageVariations()
         {
             Assert.IsNotNull(OpenAIClient.ImagesEndPoint);
 
             var imageAssetPath = Path.GetFullPath("..\\..\\..\\Assets\\image_edit_original.png");
 
             var results = await OpenAIClient.ImagesEndPoint.CreateImageVariationAsync(imageAssetPath, 1, ImageSize.Small);
+
+            Assert.IsNotNull(results);
+            Assert.NotZero(results.Count);
+
+            foreach (var result in results)
+            {
+                Console.WriteLine(result);
+            }
+        }
+
+        [Test]
+        public async Task Test_6_GenerateImageVariations_B64_Json()
+        {
+            Assert.IsNotNull(OpenAIClient.ImagesEndPoint);
+
+            var imageAssetPath = Path.GetFullPath("..\\..\\..\\Assets\\image_edit_original.png");
+
+            var results = await OpenAIClient.ImagesEndPoint.CreateImageVariationAsync(imageAssetPath, 1, ImageSize.Small, responseFormat: ResponseFormat.B64_Json);
 
             Assert.IsNotNull(results);
             Assert.NotZero(results.Count);

--- a/OpenAI-DotNet/Images/AbstractBaseImageRequest.cs
+++ b/OpenAI-DotNet/Images/AbstractBaseImageRequest.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace OpenAI.Images
+{
+    /// <summary>
+    /// Abstract base image class for making requests.
+    /// </summary>
+    public abstract class AbstractBaseImageRequest
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="Images.ResponseFormat.Url"/>
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        protected AbstractBaseImageRequest(int numberOfResults = 1, ImageSize size = ImageSize.Large, ResponseFormat responseFormat = Images.ResponseFormat.Url, string user = null)
+        {
+            Number = numberOfResults;
+
+            Size = size switch
+            {
+                ImageSize.Small => "256x256",
+                ImageSize.Medium => "512x512",
+                ImageSize.Large => "1024x1024",
+                _ => throw new ArgumentOutOfRangeException(nameof(size), size, null)
+            };
+
+            User = user;
+            ResponseFormat = responseFormat switch
+            {
+                Images.ResponseFormat.Url => "url",
+                Images.ResponseFormat.B64_Json => "b64_json",
+                _ => throw new ArgumentOutOfRangeException(nameof(responseFormat), responseFormat, null)
+            };
+        }
+
+        /// <summary>
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </summary>
+        [JsonPropertyName("n")]
+        public int Number { get; }
+
+        /// <summary>
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="Images.ResponseFormat.Url"/>
+        /// </summary>
+        [JsonPropertyName("response_format")]
+        public string ResponseFormat { get; }
+
+        /// <summary>
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </summary>
+        [JsonPropertyName("size")]
+        public string Size { get; }
+
+        /// <summary>
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </summary>
+        [JsonPropertyName("user")]
+        public string User { get; }
+    }
+}

--- a/OpenAI-DotNet/Images/ImageEditRequest.cs
+++ b/OpenAI-DotNet/Images/ImageEditRequest.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace OpenAI.Images
 {
-    public sealed class ImageEditRequest : IDisposable
+    public sealed class ImageEditRequest : AbstractBaseImageRequest, IDisposable
     {
         /// <summary>
         /// Constructor.
@@ -25,10 +25,17 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         /// <param name="responseFormat">
-        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="Images.ResponseFormat.Url"/>
         /// </param>
-        public ImageEditRequest(string imagePath, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url")
-            : this(imagePath, null, prompt, numberOfResults, size, user)
+        public ImageEditRequest(
+            string imagePath,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null, ResponseFormat responseFormat = Images.ResponseFormat.Url)
+            : this(imagePath, null, prompt, numberOfResults, size, user, responseFormat)
         {
         }
 
@@ -56,9 +63,18 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         /// <param name="responseFormat">
-        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
         /// </param>
-        public ImageEditRequest(string imagePath, string maskPath, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url")
+        public ImageEditRequest(
+            string imagePath,
+            string maskPath,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = Images.ResponseFormat.Url)
             : this(
                 File.OpenRead(imagePath),
                 Path.GetFileName(imagePath),
@@ -93,9 +109,18 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         /// <param name="responseFormat">
-        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
         /// </param>
-        public ImageEditRequest(Stream image, string imageName, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url")
+        public ImageEditRequest(
+            Stream image,
+            string imageName,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = Images.ResponseFormat.Url)
             : this(image, imageName, null, null, prompt, numberOfResults, size, user, responseFormat)
         {
         }
@@ -126,15 +151,28 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         /// <param name="responseFormat">
-        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
         /// </param>
-        public ImageEditRequest(Stream image, string imageName, Stream mask, string maskName, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url")
+        public ImageEditRequest(
+            Stream image,
+            string imageName,
+            Stream mask,
+            string maskName,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = Images.ResponseFormat.Url)
+            : base(numberOfResults, size, responseFormat, user)
         {
             Image = image;
 
             if (string.IsNullOrWhiteSpace(imageName))
             {
-                imageName = "image.png";
+                const string defaultImageName = "image.png";
+                imageName = defaultImageName;
             }
 
             ImageName = imageName;
@@ -145,7 +183,8 @@ namespace OpenAI.Images
 
                 if (string.IsNullOrWhiteSpace(maskName))
                 {
-                    maskName = "mask.png";
+                    const string defaultMaskName = "mask.png";
+                    maskName = defaultMaskName;
                 }
 
                 MaskName = maskName;
@@ -162,19 +201,6 @@ namespace OpenAI.Images
             {
                 throw new ArgumentOutOfRangeException(nameof(numberOfResults), "The number of results must be between 1 and 10");
             }
-
-            Number = numberOfResults;
-
-            Size = size switch
-            {
-                ImageSize.Small => "256x256",
-                ImageSize.Medium => "512x512",
-                ImageSize.Large => "1024x1024",
-                _ => throw new ArgumentOutOfRangeException(nameof(size), size, null)
-            };
-
-            User = user;
-            ResponseFormat = responseFormat;
         }
 
         ~ImageEditRequest() => Dispose(false);
@@ -199,26 +225,6 @@ namespace OpenAI.Images
         /// A text description of the desired image(s). The maximum length is 1000 characters.
         /// </summary>
         public string Prompt { get; }
-
-        /// <summary>
-        /// The number of images to generate. Must be between 1 and 10.
-        /// </summary>
-        public int Number { get; }
-
-        /// <summary>
-        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
-        /// </summary>
-        public string Size { get; }
-
-        /// <summary>
-        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
-        /// </summary>
-        public string User { get; }
-
-        /// <summary>
-        /// The format in which the generated images are returned. Must be one of url or b64_json. Defaults to "url"
-        /// </summary>
-        public string ResponseFormat { get; }
 
         private void Dispose(bool disposing)
         {

--- a/OpenAI-DotNet/Images/ImageEditRequest.cs
+++ b/OpenAI-DotNet/Images/ImageEditRequest.cs
@@ -24,7 +24,10 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public ImageEditRequest(string imagePath, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// </param>
+        public ImageEditRequest(string imagePath, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url")
             : this(imagePath, null, prompt, numberOfResults, size, user)
         {
         }
@@ -52,7 +55,10 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public ImageEditRequest(string imagePath, string maskPath, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// </param>
+        public ImageEditRequest(string imagePath, string maskPath, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url")
             : this(
                 File.OpenRead(imagePath),
                 Path.GetFileName(imagePath),
@@ -61,7 +67,8 @@ namespace OpenAI.Images
                 prompt,
                 numberOfResults,
                 size,
-                user)
+                user,
+                responseFormat)
         {
         }
 
@@ -85,8 +92,11 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public ImageEditRequest(Stream image, string imageName, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
-            : this(image, imageName, null, null, prompt, numberOfResults, size, user)
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// </param>
+        public ImageEditRequest(Stream image, string imageName, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url")
+            : this(image, imageName, null, null, prompt, numberOfResults, size, user, responseFormat)
         {
         }
 
@@ -115,7 +125,10 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public ImageEditRequest(Stream image, string imageName, Stream mask, string maskName, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// </param>
+        public ImageEditRequest(Stream image, string imageName, Stream mask, string maskName, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url")
         {
             Image = image;
 
@@ -161,6 +174,7 @@ namespace OpenAI.Images
             };
 
             User = user;
+            ResponseFormat = responseFormat;
         }
 
         ~ImageEditRequest() => Dispose(false);
@@ -200,6 +214,11 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </summary>
         public string User { get; }
+
+        /// <summary>
+        /// The format in which the generated images are returned. Must be one of url or b64_json. Defaults to "url"
+        /// </summary>
+        public string ResponseFormat { get; }
 
         private void Dispose(bool disposing)
         {

--- a/OpenAI-DotNet/Images/ImageGenerationRequest.cs
+++ b/OpenAI-DotNet/Images/ImageGenerationRequest.cs
@@ -6,18 +6,30 @@ namespace OpenAI.Images
     /// <summary>
     /// Creates an image given a prompt.
     /// </summary>
-    public sealed class ImageGenerationRequest
+    public sealed class ImageGenerationRequest : AbstractBaseImageRequest
     {
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="prompt">A text description of the desired image(s). The maximum length is 1000 characters.</param>
-        /// <param name="numberOfResults">The number of images to generate. Must be between 1 and 10.</param>
-        /// <param name="size">The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.</param>
-        /// <param name="user">A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.</param>
-        /// <param name="responseFormat">The format in which the generated images are returned. Must be one of url or b64_json.</param>
+        /// <param name="prompt">
+        /// A text description of the desired image(s). The maximum length is 1000 characters.
+        /// </param>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public ImageGenerationRequest(string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url")
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
+        public ImageGenerationRequest(string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, ResponseFormat responseFormat = Images.ResponseFormat.Url)
+            : base(numberOfResults, size, responseFormat, user)
         {
             if (prompt.Length > 1000)
             {
@@ -30,19 +42,6 @@ namespace OpenAI.Images
             {
                 throw new ArgumentOutOfRangeException(nameof(numberOfResults), "The number of results must be between 1 and 10");
             }
-
-            Number = numberOfResults;
-
-            Size = size switch
-            {
-                ImageSize.Small => "256x256",
-                ImageSize.Medium => "512x512",
-                ImageSize.Large => "1024x1024",
-                _ => throw new ArgumentOutOfRangeException(nameof(size), size, null)
-            };
-
-            User = user;
-            ResponseFormat = responseFormat;
         }
 
         /// <summary>
@@ -50,29 +49,5 @@ namespace OpenAI.Images
         /// </summary>
         [JsonPropertyName("prompt")]
         public string Prompt { get; }
-
-        /// <summary>
-        /// The number of images to generate. Must be between 1 and 10.
-        /// </summary>
-        [JsonPropertyName("n")]
-        public int Number { get; }
-
-        /// <summary>
-        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
-        /// </summary>
-        [JsonPropertyName("size")]
-        public string Size { get; }
-
-        /// <summary>
-        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
-        /// </summary>
-        [JsonPropertyName("user")]
-        public string User { get; }
-
-        /// <summary>
-        /// The format in which the generated images are returned. Must be one of url or b64_json. Defaults to "url"
-        /// </summary>
-        [JsonPropertyName("response_format")]
-        public string ResponseFormat { get; }
     }
 }

--- a/OpenAI-DotNet/Images/ImageGenerationRequest.cs
+++ b/OpenAI-DotNet/Images/ImageGenerationRequest.cs
@@ -15,8 +15,9 @@ namespace OpenAI.Images
         /// <param name="numberOfResults">The number of images to generate. Must be between 1 and 10.</param>
         /// <param name="size">The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.</param>
         /// <param name="user">A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.</param>
+        /// <param name="responseFormat">The format in which the generated images are returned. Must be one of url or b64_json.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public ImageGenerationRequest(string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+        public ImageGenerationRequest(string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url")
         {
             if (prompt.Length > 1000)
             {
@@ -41,6 +42,7 @@ namespace OpenAI.Images
             };
 
             User = user;
+            ResponseFormat = responseFormat;
         }
 
         /// <summary>
@@ -66,5 +68,11 @@ namespace OpenAI.Images
         /// </summary>
         [JsonPropertyName("user")]
         public string User { get; }
+
+        /// <summary>
+        /// The format in which the generated images are returned. Must be one of url or b64_json. Defaults to "url"
+        /// </summary>
+        [JsonPropertyName("response_format")]
+        public string ResponseFormat { get; }
     }
 }

--- a/OpenAI-DotNet/Images/ImageResult.cs
+++ b/OpenAI-DotNet/Images/ImageResult.cs
@@ -7,5 +7,9 @@ namespace OpenAI.Images
         [JsonInclude]
         [JsonPropertyName("url")]
         public string Url { get; private set; }
+
+        [JsonInclude]
+        [JsonPropertyName("b64_json")]
+        public string B64_Json { get; private set; }
     }
 }

--- a/OpenAI-DotNet/Images/ImageVariationRequest.cs
+++ b/OpenAI-DotNet/Images/ImageVariationRequest.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace OpenAI.Images
 {
-    public sealed class ImageVariationRequest : IDisposable
+    public sealed class ImageVariationRequest : AbstractBaseImageRequest, IDisposable
     {
         /// <summary>
         /// Constructor.
@@ -21,9 +21,11 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         /// <param name="responseFormat">
-        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
         /// </param>
-        public ImageVariationRequest(string imagePath, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url")
+        public ImageVariationRequest(string imagePath, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, ResponseFormat responseFormat = Images.ResponseFormat.Url)
             : this(File.OpenRead(imagePath), Path.GetFileName(imagePath), numberOfResults, size, user, responseFormat)
         {
         }
@@ -47,15 +49,19 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         /// <param name="responseFormat">
-        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
         /// </param>
-        public ImageVariationRequest(Stream image, string imageName, int numberOfResults, ImageSize size, string user, string responseFormat = "url")
+        public ImageVariationRequest(Stream image, string imageName, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, ResponseFormat responseFormat = Images.ResponseFormat.Url)
+            : base(numberOfResults, size, responseFormat, user)
         {
             Image = image;
 
             if (string.IsNullOrWhiteSpace(imageName))
             {
-                imageName = "image.png";
+                const string defaultImageName = "image.png";
+                imageName = defaultImageName;
             }
 
             ImageName = imageName;
@@ -64,19 +70,6 @@ namespace OpenAI.Images
             {
                 throw new ArgumentOutOfRangeException(nameof(numberOfResults), "The number of results must be between 1 and 10");
             }
-
-            Number = numberOfResults;
-
-            Size = size switch
-            {
-                ImageSize.Small => "256x256",
-                ImageSize.Medium => "512x512",
-                ImageSize.Large => "1024x1024",
-                _ => throw new ArgumentOutOfRangeException(nameof(size), size, null)
-            };
-
-            User = user;
-            ResponseFormat = responseFormat;
         }
 
         ~ImageVariationRequest() => Dispose(false);
@@ -87,26 +80,6 @@ namespace OpenAI.Images
         public Stream Image { get; }
 
         public string ImageName { get; }
-
-        /// <summary>
-        /// The number of images to generate. Must be between 1 and 10.
-        /// </summary>
-        public int Number { get; }
-
-        /// <summary>
-        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
-        /// </summary>
-        public string Size { get; }
-
-        /// <summary>
-        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
-        /// </summary>
-        public string User { get; }
-
-        /// <summary>
-        /// The format in which the generated images are returned. Must be one of url or b64_json. Defaults to "url"
-        /// </summary>
-        public string ResponseFormat { get; }
 
         private void Dispose(bool disposing)
         {

--- a/OpenAI-DotNet/Images/ImageVariationRequest.cs
+++ b/OpenAI-DotNet/Images/ImageVariationRequest.cs
@@ -20,8 +20,11 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public ImageVariationRequest(string imagePath, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
-            : this(File.OpenRead(imagePath), Path.GetFileName(imagePath), numberOfResults, size, user)
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// </param>
+        public ImageVariationRequest(string imagePath, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url")
+            : this(File.OpenRead(imagePath), Path.GetFileName(imagePath), numberOfResults, size, user, responseFormat)
         {
         }
 
@@ -43,7 +46,10 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public ImageVariationRequest(Stream image, string imageName, int numberOfResults, ImageSize size, string user)
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// </param>
+        public ImageVariationRequest(Stream image, string imageName, int numberOfResults, ImageSize size, string user, string responseFormat = "url")
         {
             Image = image;
 
@@ -70,6 +76,7 @@ namespace OpenAI.Images
             };
 
             User = user;
+            ResponseFormat = responseFormat;
         }
 
         ~ImageVariationRequest() => Dispose(false);
@@ -95,6 +102,11 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </summary>
         public string User { get; }
+
+        /// <summary>
+        /// The format in which the generated images are returned. Must be one of url or b64_json. Defaults to "url"
+        /// </summary>
+        public string ResponseFormat { get; }
 
         private void Dispose(bool disposing)
         {

--- a/OpenAI-DotNet/Images/ImagesEndpoint.cs
+++ b/OpenAI-DotNet/Images/ImagesEndpoint.cs
@@ -23,14 +23,33 @@ namespace OpenAI.Images
         /// <summary>
         /// Creates an image given a prompt.
         /// </summary>
-        /// <param name="prompt">A text description of the desired image(s). The maximum length is 1000 characters.</param>
-        /// <param name="numberOfResults">The number of images to generate. Must be between 1 and 10.</param>
-        /// <param name="size">The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.</param>
-        /// <param name="user">A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.</param>
-        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
-        /// <param name="responseFormat">The format in which the generated images are returned. Must be one of url or b64_json.</param>        
+        /// <param name="prompt">
+        /// A text description of the desired image(s). The maximum length is 1000 characters.
+        /// </param>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Optional, <see cref="CancellationToken"/>.
+        /// </param>
         /// <returns>A list of generated texture urls to download.</returns>
-        public async Task<IReadOnlyList<string>> GenerateImageAsync(string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url", CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<string>> GenerateImageAsync(
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = ResponseFormat.Url,
+            CancellationToken cancellationToken = default)
             => await GenerateImageAsync(new ImageGenerationRequest(prompt, numberOfResults, size, user, responseFormat), cancellationToken).ConfigureAwait(false);
 
         /// <summary>
@@ -44,7 +63,7 @@ namespace OpenAI.Images
         {
             var jsonContent = JsonSerializer.Serialize(request, Api.JsonSerializationOptions).ToJsonStringContent();
             var response = await Api.Client.PostAsync(GetUrl("/generations"), jsonContent, cancellationToken).ConfigureAwait(false);
-            return await DeserializeResponseAsync(response, request.ResponseFormat, cancellationToken).ConfigureAwait(false);
+            return await DeserializeResponseAsync(response, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -67,13 +86,26 @@ namespace OpenAI.Images
         /// <param name="size">
         /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
         /// </param>
-        /// <param name="user">A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.</param>
-        /// <param name="responseFormat">The format in which the generated images are returned. Must be one of url or b64_json.</param>
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns>A list of generated texture urls to download.</returns>
         /// <exception cref="HttpRequestException"></exception>
-        public async Task<IReadOnlyList<string>> CreateImageEditAsync(string image, string mask, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url", CancellationToken cancellationToken = default)
-            => await CreateImageEditAsync(new ImageEditRequest(image, mask, prompt, numberOfResults, size, user), cancellationToken).ConfigureAwait(false);
+        public async Task<IReadOnlyList<string>> CreateImageEditAsync(
+            string image,
+            string mask,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            ResponseFormat responseFormat = ResponseFormat.Url,
+            string user = null,
+            CancellationToken cancellationToken = default)
+            => await CreateImageEditAsync(new ImageEditRequest(image, mask, prompt, numberOfResults, size, user, responseFormat), cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Creates an edited or extended image given an original image and a prompt.
@@ -107,9 +139,8 @@ namespace OpenAI.Images
             }
 
             request.Dispose();
-
             var response = await Api.Client.PostAsync(GetUrl("/edits"), content, cancellationToken).ConfigureAwait(false);
-            return await DeserializeResponseAsync(response, request.ResponseFormat, cancellationToken).ConfigureAwait(false);
+            return await DeserializeResponseAsync(response, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -125,16 +156,23 @@ namespace OpenAI.Images
         /// <param name="size">
         /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
         /// </param>
-        /// <param name="user">
-        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
-        /// </param>
         /// <param name="responseFormat">
         /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns>A list of generated texture urls to download.</returns>
         /// <exception cref="HttpRequestException"></exception>
-        public async Task<IReadOnlyList<string>> CreateImageVariationAsync(string imagePath, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, string responseFormat = "url", CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<string>> CreateImageVariationAsync(
+            string imagePath,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            ResponseFormat responseFormat = ResponseFormat.Url,
+            string user = null,
+            CancellationToken cancellationToken = default)
             => await CreateImageVariationAsync(new ImageVariationRequest(imagePath, numberOfResults, size, user, responseFormat), cancellationToken).ConfigureAwait(false);
 
         /// <summary>
@@ -160,12 +198,11 @@ namespace OpenAI.Images
             }
 
             request.Dispose();
-
             var response = await Api.Client.PostAsync(GetUrl("/variations"), content, cancellationToken).ConfigureAwait(false);
-            return await DeserializeResponseAsync(response, request.ResponseFormat, cancellationToken).ConfigureAwait(false);
+            return await DeserializeResponseAsync(response, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<IReadOnlyList<string>> DeserializeResponseAsync(HttpResponseMessage response, string responseFormat = "url", CancellationToken cancellationToken = default)
+        private async Task<IReadOnlyList<string>> DeserializeResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken = default)
         {
             var resultAsString = await response.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             var imagesResponse = JsonSerializer.Deserialize<ImagesResponse>(resultAsString, Api.JsonSerializationOptions);
@@ -176,11 +213,7 @@ namespace OpenAI.Images
             }
 
             imagesResponse.SetResponseData(response.Headers);
-            
-            if(responseFormat == "b64_json")
-                return imagesResponse.Data.Select(imageResult => imageResult.B64_Json).ToList();
-            
-            return imagesResponse.Data.Select(imageResult => imageResult.Url).ToList();
+            return imagesResponse.Data.Select(imageResult => string.IsNullOrWhiteSpace(imageResult.Url) ? imageResult.B64_Json : imageResult.Url).ToList();
         }
     }
 }

--- a/OpenAI-DotNet/Images/ResponseFormat.cs
+++ b/OpenAI-DotNet/Images/ResponseFormat.cs
@@ -1,0 +1,8 @@
+﻿namespace OpenAI.Images
+{
+    public enum ResponseFormat
+    {
+        Url,
+        B64_Json
+    }
+}

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -17,8 +17,9 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <RepositoryUrl>https://github.com/RageAgainstThePixel/OpenAI-DotNet</RepositoryUrl>
     <PackageTags>OpenAI, AI, ML, API, gpt-4, gpt-3.5-tubo, gpt-3, chatGPT, chat-gpt, gpt-2, gpt</PackageTags>
     <Title>OpenAI API</Title>
-    <PackageReleaseNotes>6.5.4
-- Added response_format to image/generations, image/edits and image/variations requests
+    <PackageReleaseNotes>6.6.0
+- Added ResponseFormat to ImageGenerationRequests
+- Refactored Image Requests with AbstractBaseImageRequest
 Version 6.5.3
 - Added missing ConfigureAwait to await calls
 Version 6.5.2
@@ -106,7 +107,7 @@ Version 4.4.0
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
     <PackageId>OpenAI-DotNet</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.6.0</Version>
     <Company>RageAgainstThePixel</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>Assets\OpenAI-DotNet-Icon.png</PackageIcon>

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -17,7 +17,9 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <RepositoryUrl>https://github.com/RageAgainstThePixel/OpenAI-DotNet</RepositoryUrl>
     <PackageTags>OpenAI, AI, ML, API, gpt-4, gpt-3.5-tubo, gpt-3, chatGPT, chat-gpt, gpt-2, gpt</PackageTags>
     <Title>OpenAI API</Title>
-    <PackageReleaseNotes>Version 6.5.3
+    <PackageReleaseNotes>6.5.4
+- Added response_format to image/generations, image/edits and image/variations
+Version 6.5.3
 - Added missing ConfigureAwait to await calls
 Version 6.5.2
 - Updated SetResponseData to better reflect the difference between OpenAI and Azure responses.
@@ -104,7 +106,7 @@ Version 4.4.0
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
     <PackageId>OpenAI-DotNet</PackageId>
-    <Version>6.5.3</Version>
+    <Version>6.5.4</Version>
     <Company>RageAgainstThePixel</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>Assets\OpenAI-DotNet-Icon.png</PackageIcon>

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -18,7 +18,7 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <PackageTags>OpenAI, AI, ML, API, gpt-4, gpt-3.5-tubo, gpt-3, chatGPT, chat-gpt, gpt-2, gpt</PackageTags>
     <Title>OpenAI API</Title>
     <PackageReleaseNotes>6.5.4
-- Added response_format to image/generations, image/edits and image/variations
+- Added response_format to image/generations, image/edits and image/variations requests
 Version 6.5.3
 - Added missing ConfigureAwait to await calls
 Version 6.5.2


### PR DESCRIPTION
- Added [`response_format`](https://platform.openai.com/docs/api-reference/images/create#images/create-response_format) to `ImageGenerationRequest`
- Refactored Image Requests with AbstractBaseImageRequest