### PR TITLE
OpenAI-DotNet 6.7.0

### DIFF
--- a/OpenAI-DotNet-Tests/TestFixture_03_Chat.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_03_Chat.cs
@@ -13,14 +13,14 @@ namespace OpenAI.Tests
         public async Task Test_1_GetChatCompletion()
         {
             Assert.IsNotNull(OpenAIClient.ChatEndpoint);
-            var chatPrompts = new List<ChatPrompt>
+            var messages = new List<Message>
             {
-                new ChatPrompt("system", "You are a helpful assistant."),
-                new ChatPrompt("user", "Who won the world series in 2020?"),
-                new ChatPrompt("assistant", "The Los Angeles Dodgers won the World Series in 2020."),
-                new ChatPrompt("user", "Where was it played?"),
+                new Message(Role.System, "You are a helpful assistant."),
+                new Message(Role.User, "Who won the world series in 2020?"),
+                new Message(Role.Assistant, "The Los Angeles Dodgers won the World Series in 2020."),
+                new Message(Role.User, "Where was it played?"),
             };
-            var chatRequest = new ChatRequest(chatPrompts, Model.GPT3_5_Turbo);
+            var chatRequest = new ChatRequest(messages, Model.GPT3_5_Turbo);
             var result = await OpenAIClient.ChatEndpoint.GetCompletionAsync(chatRequest);
             Assert.IsNotNull(result);
             Assert.NotNull(result.Choices);
@@ -32,14 +32,14 @@ namespace OpenAI.Tests
         public async Task Test_2_GetChatStreamingCompletion()
         {
             Assert.IsNotNull(OpenAIClient.ChatEndpoint);
-            var chatPrompts = new List<ChatPrompt>
+            var messages = new List<Message>
             {
-                new ChatPrompt("system", "You are a helpful assistant."),
-                new ChatPrompt("user", "Who won the world series in 2020?"),
-                new ChatPrompt("assistant", "The Los Angeles Dodgers won the World Series in 2020."),
-                new ChatPrompt("user", "Where was it played?"),
+                new Message(Role.System, "You are a helpful assistant."),
+                new Message(Role.User, "Who won the world series in 2020?"),
+                new Message(Role.Assistant, "The Los Angeles Dodgers won the World Series in 2020."),
+                new Message(Role.User, "Where was it played?"),
             };
-            var chatRequest = new ChatRequest(chatPrompts, Model.GPT3_5_Turbo);
+            var chatRequest = new ChatRequest(messages, Model.GPT3_5_Turbo);
             var allContent = new List<string>();
 
             await OpenAIClient.ChatEndpoint.StreamCompletionAsync(chatRequest, result =>
@@ -50,21 +50,21 @@ namespace OpenAI.Tests
                 allContent.Add(result.FirstChoice);
             });
 
-            Console.WriteLine(string.Join("", allContent));
+            Console.WriteLine(string.Join(string.Empty, allContent));
         }
 
         [Test]
         public async Task Test_3_GetChatStreamingCompletionEnumerableAsync()
         {
             Assert.IsNotNull(OpenAIClient.ChatEndpoint);
-            var chatPrompts = new List<ChatPrompt>
+            var messages = new List<Message>
             {
-                new ChatPrompt("system", "You are a helpful assistant."),
-                new ChatPrompt("user", "Who won the world series in 2020?"),
-                new ChatPrompt("assistant", "The Los Angeles Dodgers won the World Series in 2020."),
-                new ChatPrompt("user", "Where was it played?"),
+                new Message(Role.System, "You are a helpful assistant."),
+                new Message(Role.User, "Who won the world series in 2020?"),
+                new Message(Role.Assistant, "The Los Angeles Dodgers won the World Series in 2020."),
+                new Message(Role.User, "Where was it played?"),
             };
-            var chatRequest = new ChatRequest(chatPrompts, Model.GPT3_5_Turbo);
+            var chatRequest = new ChatRequest(messages, Model.GPT3_5_Turbo);
             var allContent = new List<string>();
 
             await foreach (var result in OpenAIClient.ChatEndpoint.StreamCompletionEnumerableAsync(chatRequest))
@@ -75,7 +75,7 @@ namespace OpenAI.Tests
                 allContent.Add(result.FirstChoice);
             }
 
-            Console.WriteLine(string.Join("", allContent));
+            Console.WriteLine(string.Join(string.Empty, allContent));
         }
     }
 }

--- a/OpenAI-DotNet/Chat/ChatPrompt.cs
+++ b/OpenAI-DotNet/Chat/ChatPrompt.cs
@@ -1,23 +1,40 @@
-using System.Text.Json;
+using System;
 using System.Text.Json.Serialization;
 
 namespace OpenAI.Chat
 {
+    [Obsolete("Use OpenAI.Chat.Message instead")]
     public sealed class ChatPrompt
     {
-        [JsonConstructor]
+        [Obsolete("Use OpenAI.Chat.Message instead")]
         public ChatPrompt(string role, string content)
+        {
+            Role = role.ToLower() switch
+            {
+                "system" => Role.System,
+                "assistant" => Role.Assistant,
+                "user" => Role.User,
+                _ => throw new ArgumentException(nameof(role))
+            };
+            Content = content;
+        }
+
+        [JsonConstructor]
+        [Obsolete("Use OpenAI.Chat.Message instead")]
+        public ChatPrompt(Role role, string content)
         {
             Role = role;
             Content = content;
         }
 
         [JsonPropertyName("role")]
-        public string Role { get; }
+        public Role Role { get; }
 
         [JsonPropertyName("content")]
         public string Content { get; }
 
-        public override string ToString() => JsonSerializer.Serialize(this);
+        public static implicit operator ChatPrompt(Message message) => new ChatPrompt(message.Role, message.Content);
+
+        public static implicit operator Message(ChatPrompt message) => new Message(message.Role, message.Content);
     }
 }

--- a/OpenAI-DotNet/Chat/ChatRequest.cs
+++ b/OpenAI-DotNet/Chat/ChatRequest.cs
@@ -12,9 +12,12 @@ namespace OpenAI.Chat
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="messages"></param>
+        /// <param name="messages">
+        /// The list of messages for the current chat session.
+        /// </param>
         /// <param name="model">
-        /// ID of the model to use. Currently, only gpt-3.5-turbo and gpt-3.5-turbo-0301 are supported.
+        /// ID of the model to use.<br/>
+        /// Currently, only gpt-4, gpt-3.5-turbo and gpt-3.5-turbo-0301 are supported.
         /// </param>
         /// <param name="temperature">
         /// What sampling temperature to use, between 0 and 2.
@@ -66,7 +69,7 @@ namespace OpenAI.Chat
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         public ChatRequest(
-            IEnumerable<ChatPrompt> messages,
+            IEnumerable<Message> messages,
             Model model = null,
             double? temperature = null,
             double? topP = null,
@@ -104,6 +107,21 @@ namespace OpenAI.Chat
             User = user;
         }
 
+        [Obsolete("Use ChatRequest(IEnumerable<Message> messages) instead")]
+        public ChatRequest(
+            IEnumerable<ChatPrompt> messages,
+            Model model = null,
+            double? temperature = null,
+            double? topP = null,
+            int? number = null,
+            string[] stops = null,
+            int? maxTokens = null,
+            double? presencePenalty = null,
+            double? frequencyPenalty = null,
+            Dictionary<string, double> logitBias = null,
+            string user = null)
+        => throw new NotImplementedException();
+
         /// <summary>
         /// ID of the model to use. Currently, only gpt-3.5-turbo and gpt-3.5-turbo-0301 are supported.
         /// </summary>
@@ -114,7 +132,7 @@ namespace OpenAI.Chat
         /// The messages to generate chat completions for, in the chat format.
         /// </summary>
         [JsonPropertyName("messages")]
-        public IReadOnlyList<ChatPrompt> Messages { get; }
+        public IReadOnlyList<Message> Messages { get; }
 
         /// <summary>
         /// What sampling temperature to use, between 0 and 2.
@@ -199,7 +217,5 @@ namespace OpenAI.Chat
         /// </summary>
         [JsonPropertyName("user")]
         public string User { get; }
-
-        public override string ToString() => JsonSerializer.Serialize(this);
     }
 }

--- a/OpenAI-DotNet/Chat/ChatResponse.cs
+++ b/OpenAI-DotNet/Chat/ChatResponse.cs
@@ -33,7 +33,5 @@ namespace OpenAI.Chat
 
         [JsonIgnore]
         public Choice FirstChoice => Choices.FirstOrDefault();
-
-        public override string ToString() => JsonSerializer.Serialize(this);
     }
 }

--- a/OpenAI-DotNet/Chat/Choice.cs
+++ b/OpenAI-DotNet/Chat/Choice.cs
@@ -20,7 +20,7 @@ namespace OpenAI.Chat
         [JsonPropertyName("index")]
         public int Index { get; private set; }
 
-        public override string ToString() => Message?.ToString() ?? Delta.Content;
+        public override string ToString() => Message?.Content ?? Delta.Content;
 
         public static implicit operator string(Choice choice) => choice.ToString();
     }

--- a/OpenAI-DotNet/Chat/Delta.cs
+++ b/OpenAI-DotNet/Chat/Delta.cs
@@ -6,7 +6,7 @@ namespace OpenAI.Chat
     {
         [JsonInclude]
         [JsonPropertyName("role")]
-        public string Role { get; private set; }
+        public Role Role { get; private set; }
 
         [JsonInclude]
         [JsonPropertyName("content")]

--- a/OpenAI-DotNet/Chat/Message.cs
+++ b/OpenAI-DotNet/Chat/Message.cs
@@ -4,15 +4,19 @@ namespace OpenAI.Chat
 {
     public sealed class Message
     {
+        public Message(Role role, string content)
+        {
+            Role = role;
+            Content = content;
+        }
+
         [JsonInclude]
         [JsonPropertyName("role")]
-        public string Role { get; private set; }
+        public Role Role { get; private set; }
 
         [JsonInclude]
         [JsonPropertyName("content")]
         public string Content { get; private set; }
-
-        public override string ToString() => Content;
 
         public static implicit operator string(Message message) => message.Content;
     }

--- a/OpenAI-DotNet/Chat/Role.cs
+++ b/OpenAI-DotNet/Chat/Role.cs
@@ -1,0 +1,14 @@
+using System.Runtime.Serialization;
+
+namespace OpenAI.Chat
+{
+    public enum Role
+    {
+        [EnumMember(Value = "system")]
+        System = 1,
+        [EnumMember(Value = "assistant")]
+        Assistant = 2,
+        [EnumMember(Value = "user")]
+        User = 3,
+    }
+}

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -19,7 +19,7 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <Title>OpenAI API</Title>
     <PackageReleaseNotes>Version 6.7.0
 - Deprecated ChatPrompt -&gt; Message
-- Added Role enum for chat messages
+- Added Role enum for Chat.Messages and Chat.Delta
 - Updated ChatRequest constructor to use IEnumerable&lt;Message&gt; messages
 - Updated ChatRequest.Messages to IReadonlyList&lt;Message&gt;
 - Updated unit tests

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -17,7 +17,13 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <RepositoryUrl>https://github.com/RageAgainstThePixel/OpenAI-DotNet</RepositoryUrl>
     <PackageTags>OpenAI, AI, ML, API, gpt-4, gpt-3.5-tubo, gpt-3, chatGPT, chat-gpt, gpt-2, gpt</PackageTags>
     <Title>OpenAI API</Title>
-    <PackageReleaseNotes>6.6.0
+    <PackageReleaseNotes>Version 6.7.0
+- Deprecated ChatPrompt -&gt; Message
+- Added Role enum for chat messages
+- Updated ChatRequest constructor to use IEnumerable&lt;Message&gt; messages
+- Updated ChatRequest.Messages to IReadonlyList&lt;Message&gt;
+- Updated unit tests
+Version 6.6.0
 - Added ResponseFormat to ImageGenerationRequests
 - Refactored Image Requests with AbstractBaseImageRequest
 Version 6.5.3
@@ -107,7 +113,7 @@ Version 4.4.0
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
     <PackageId>OpenAI-DotNet</PackageId>
-    <Version>6.6.0</Version>
+    <Version>6.7.0</Version>
     <Company>RageAgainstThePixel</Company>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>Assets\OpenAI-DotNet-Icon.png</PackageIcon>

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -65,7 +65,11 @@ namespace OpenAI
             Client = SetupClient();
             JsonSerializationOptions = new JsonSerializerOptions
             {
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                Converters =
+                {
+                    new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)
+                }
             };
             ModelsEndpoint = new ModelsEndpoint(this);
             CompletionsEndpoint = new CompletionsEndpoint(this);


### PR DESCRIPTION
- Deprecated `ChatPrompt` -> `Message`
- Added `Role` enum for `Chat.Messages` and `Chat.Delta`
- Updated `ChatRequest` constructor to use `IEnumerable<Message> messages`
- Updated `ChatRequest.Messages` to `IReadonlyList<Message>`
- Updated unit tests