### PR TITLE
Improved DI

### DIFF
--- a/OpenAI-DotNet/Audio/AudioEndpoint.cs
+++ b/OpenAI-DotNet/Audio/AudioEndpoint.cs
@@ -12,7 +12,7 @@ namespace OpenAI.Audio
     /// Transforms audio into text.<br/>
     /// <see href="https://platform.openai.com/docs/api-reference/audio"/>
     /// </summary>
-    public sealed class AudioEndpoint : BaseEndPoint
+    public sealed class AudioEndpoint : BaseEndPoint, IAudioEndpoint
     {
         private class AudioResponse
         {

--- a/OpenAI-DotNet/Audio/IAudioEndpoint.cs
+++ b/OpenAI-DotNet/Audio/IAudioEndpoint.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenAI.Audio;
+
+public interface IAudioEndpoint
+{
+    /// <summary>
+    /// Transcribes audio into the input language.
+    /// </summary>
+    /// <param name="request"><see cref="AudioTranscriptionRequest"/>.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>The transcribed text.</returns>
+    Task<string> CreateTranscriptionAsync(AudioTranscriptionRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Translates audio into English.
+    /// </summary>
+    /// <param name="request"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>The translated text.</returns>
+    Task<string> CreateTranslationAsync(AudioTranslationRequest request, CancellationToken cancellationToken = default);
+}

--- a/OpenAI-DotNet/Chat/ChatEndpoint.cs
+++ b/OpenAI-DotNet/Chat/ChatEndpoint.cs
@@ -15,7 +15,7 @@ namespace OpenAI.Chat
     /// Given a chat conversation, the model will return a chat completion response.<br/>
     /// <see href="https://platform.openai.com/docs/api-reference/chat"/>
     /// </summary>
-    public sealed class ChatEndpoint : BaseEndPoint
+    public sealed class ChatEndpoint : BaseEndPoint, IChatEndpoint
     {
         /// <inheritdoc />
         public ChatEndpoint(OpenAIClient api) : base(api) { }

--- a/OpenAI-DotNet/Chat/IChatEndpoint.cs
+++ b/OpenAI-DotNet/Chat/IChatEndpoint.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenAI.Chat;
+
+public interface IChatEndpoint
+{
+    /// <summary>
+    /// Creates a completion for the chat message
+    /// </summary>
+    /// <param name="chatRequest">The chat request which contains the message content.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns><see cref="ChatResponse"/>.</returns>
+    Task<ChatResponse> GetCompletionAsync(ChatRequest chatRequest, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Created a completion for the chat message and stream the results to the <paramref name="resultHandler"/> as they come in.
+    /// </summary>
+    /// <param name="chatRequest">The chat request which contains the message content.</param>
+    /// <param name="resultHandler">An action to be called as each new result arrives.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns><see cref="ChatResponse"/>.</returns>
+    /// <exception cref="HttpRequestException">Raised when the HTTP request fails</exception>
+    Task<ChatResponse> StreamCompletionAsync(ChatRequest chatRequest, Action<ChatResponse> resultHandler,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Created a completion for the chat message and stream the results as they come in.<br/>
+    /// If you are not using C# 8 supporting IAsyncEnumerable{T} or if you are using the .NET Framework,
+    /// you may need to use <see cref="StreamCompletionAsync(ChatRequest, Action{ChatResponse}, CancellationToken)"/> instead.
+    /// </summary>
+    /// <param name="chatRequest">The chat request which contains the message content.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns><see cref="ChatResponse"/>.</returns>
+    /// <exception cref="HttpRequestException">Raised when the HTTP request fails</exception>
+    IAsyncEnumerable<ChatResponse> StreamCompletionEnumerableAsync(ChatRequest chatRequest,
+        CancellationToken cancellationToken = default);
+}

--- a/OpenAI-DotNet/Completions/CompletionsEndpoint.cs
+++ b/OpenAI-DotNet/Completions/CompletionsEndpoint.cs
@@ -19,7 +19,7 @@ namespace OpenAI.Completions
     /// (see the prompt library for inspiration).<br/>
     /// <see href="https://platform.openai.com/docs/api-reference/completions"/>
     /// </summary>
-    public sealed class CompletionsEndpoint : BaseEndPoint
+    public sealed class CompletionsEndpoint : BaseEndPoint, ICompletionsEndpoint
     {
         /// <inheritdoc />
         internal CompletionsEndpoint(OpenAIClient api) : base(api) { }

--- a/OpenAI-DotNet/Completions/ICompletionsEndpoint.cs
+++ b/OpenAI-DotNet/Completions/ICompletionsEndpoint.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenAI.Models;
+
+namespace OpenAI.Completions;
+
+public interface ICompletionsEndpoint
+{
+    /// <summary>
+    /// Ask the API to complete the prompt(s) using the specified parameters.
+    /// This is non-streaming, so it will wait until the API returns the full result.
+    /// </summary>
+    /// <param name="prompt">The prompt to generate from</param>
+    /// <param name="prompts">The prompts to generate from</param>
+    /// <param name="suffix">The suffix that comes after a completion of inserted text.</param>
+    /// <param name="maxTokens">How many tokens to complete to. Can return fewer if a stop sequence is hit.</param>
+    /// <param name="temperature">What sampling temperature to use. Higher values means the model will take more risks.
+    /// Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.
+    /// It is generally recommend to use this or <paramref name="topP"/> but not both.</param>
+    /// <param name="topP">An alternative to sampling with temperature, called nucleus sampling,
+    /// where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens
+    /// comprising the top 10% probability mass are considered. It is generally recommend to use this or
+    /// <paramref name="temperature"/> but not both.</param>
+    /// <param name="numOutputs">How many different choices to request for each prompt.</param>
+    /// <param name="presencePenalty">The scale of the penalty applied if a token is already present at all.
+    /// Should generally be between 0 and 1, although negative numbers are allowed to encourage token reuse.</param>
+    /// <param name="frequencyPenalty">The scale of the penalty for how often a token is used.
+    /// Should generally be between 0 and 1, although negative numbers are allowed to encourage token reuse.</param>
+    /// <param name="logProbabilities">Include the log probabilities on the logprobs most likely tokens, which can be found
+    /// in <see cref="CompletionResult.Completions"/> -> <see cref="Choice.LogProbabilities"/>. So for example, if logprobs is 10,
+    /// the API will return a list of the 10 most likely tokens. If logprobs is supplied, the API will always return the logprob
+    /// of the sampled token, so there may be up to logprobs+1 elements in the response.</param>
+    /// <param name="echo">Echo back the prompt in addition to the completion.</param>
+    /// <param name="stopSequences">One or more sequences where the API will stop generating further tokens.
+    /// The returned text will not contain the stop sequence.</param>
+    /// <param name="model">Optional, <see cref="Model"/> to use when calling the API.
+    /// Defaults to <see cref="Model.Davinci"/>.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>
+    /// Asynchronously returns the completion result.
+    /// Look in its <see cref="CompletionResult.Completions"/> property for the completions.
+    /// </returns>
+    Task<CompletionResult> CreateCompletionAsync(
+        string prompt = null,
+        IEnumerable<string> prompts = null,
+        string suffix = null,
+        int? maxTokens = null,
+        double? temperature = null,
+        double? topP = null,
+        int? numOutputs = null,
+        double? presencePenalty = null,
+        double? frequencyPenalty = null,
+        int? logProbabilities = null,
+        bool? echo = null,
+        IEnumerable<string> stopSequences = null,
+        Model model = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Ask the API to complete the prompt(s) using the specified request.
+    /// This is non-streaming, so it will wait until the API returns the full result.
+    /// </summary>
+    /// <param name="completionRequest">The request to send to the API.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>Asynchronously returns the completion result.
+    /// Look in its <see cref="CompletionResult.Completions"/> property for the completions.</returns>
+    /// <exception cref="HttpRequestException">Raised when the HTTP request fails</exception>
+    Task<CompletionResult> CreateCompletionAsync(CompletionRequest completionRequest,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Ask the API to complete the prompt(s) using the specified request,
+    /// and stream the results to the <paramref name="resultHandler"/> as they come in.
+    /// </summary>
+    /// <param name="resultHandler">An action to be called as each new result arrives.</param>
+    /// <param name="prompt">The prompt to generate from</param>
+    /// <param name="prompts">The prompts to generate from</param>
+    /// <param name="suffix">The suffix that comes after a completion of inserted text.</param>
+    /// <param name="maxTokens">How many tokens to complete to. Can return fewer if a stop sequence is hit.</param>
+    /// <param name="temperature">What sampling temperature to use. Higher values means the model will take more risks.
+    /// Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.
+    /// It is generally recommend to use this or <paramref name="topP"/> but not both.</param>
+    /// <param name="topP">An alternative to sampling with temperature, called nucleus sampling,
+    /// where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens
+    /// comprising the top 10% probability mass are considered. It is generally recommend to use this
+    /// or <paramref name="temperature"/> but not both.</param>
+    /// <param name="numOutputs">How many different choices to request for each prompt.</param>
+    /// <param name="presencePenalty">The scale of the penalty applied if a token is already present at all.
+    /// Should generally be between 0 and 1, although negative numbers are allowed to encourage token reuse.</param>
+    /// <param name="frequencyPenalty">The scale of the penalty for how often a token is used.
+    /// Should generally be between 0 and 1, although negative numbers are allowed to encourage token reuse.</param>
+    /// <param name="logProbabilities">Include the log probabilities on the logProbabilities most likely tokens,
+    /// which can be found in <see cref="CompletionResult.Completions"/> -> <see cref="Choice.LogProbabilities"/>.
+    /// So for example, if logProbabilities is 10, the API will return a list of the 10 most likely tokens.
+    /// If logProbabilities is supplied, the API will always return the logProbabilities of the sampled token,
+    /// so there may be up to logProbabilities+1 elements in the response.</param>
+    /// <param name="echo">Echo back the prompt in addition to the completion.</param>
+    /// <param name="stopSequences">One or more sequences where the API will stop generating further tokens.
+    /// The returned text will not contain the stop sequence.</param>
+    /// <param name="model">Optional, <see cref="Model"/> to use when calling the API.
+    /// Defaults to <see cref="Model.Davinci"/>.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>An async enumerable with each of the results as they come in.
+    /// See <see href="https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-8#asynchronous-streams">the C# docs</see>
+    /// for more details on how to consume an async enumerable.</returns>
+    Task StreamCompletionAsync(
+        Action<CompletionResult> resultHandler,
+        string prompt = null,
+        IEnumerable<string> prompts = null,
+        string suffix = null,
+        int? maxTokens = null,
+        double? temperature = null,
+        double? topP = null,
+        int? numOutputs = null,
+        double? presencePenalty = null,
+        double? frequencyPenalty = null,
+        int? logProbabilities = null,
+        bool? echo = null,
+        IEnumerable<string> stopSequences = null,
+        Model model = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Ask the API to complete the prompt(s) using the specified request,
+    /// and stream the results to the <paramref name="resultHandler"/> as they come in.
+    /// </summary>
+    /// <param name="completionRequest">The request to send to the API.</param>
+    /// <param name="resultHandler">An action to be called as each new result arrives.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <exception cref="HttpRequestException">Raised when the HTTP request fails</exception>
+    Task StreamCompletionAsync(CompletionRequest completionRequest, Action<CompletionResult> resultHandler,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Ask the API to complete the prompt(s) using the specified request, and stream the results as they come in.<br/>
+    /// If you are not using C# 8 supporting IAsyncEnumerable{T} or if you are using the .NET Framework,
+    /// you may need to use <see cref="StreamCompletionAsync(CompletionRequest, Action{CompletionResult}, CancellationToken)"/> instead.
+    /// </summary>
+    /// <param name="prompt">The prompt to generate from</param>
+    /// <param name="prompts">The prompts to generate from</param>
+    /// <param name="suffix">The suffix that comes after a completion of inserted text.</param>
+    /// <param name="maxTokens">How many tokens to complete to. Can return fewer if a stop sequence is hit.</param>
+    /// <param name="temperature">What sampling temperature to use. Higher values means the model will take more risks.
+    /// Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.
+    /// It is generally recommend to use this or <paramref name="topP"/> but not both.</param>
+    /// <param name="topP">An alternative to sampling with temperature, called nucleus sampling,
+    /// where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens
+    /// comprising the top 10% probability mass are considered. It is generally recommend to use this
+    /// or <paramref name="temperature"/> but not both.</param>
+    /// <param name="numOutputs">How many different choices to request for each prompt.</param>
+    /// <param name="presencePenalty">The scale of the penalty applied if a token is already present at all.
+    /// Should generally be between 0 and 1, although negative numbers are allowed to encourage token reuse.</param>
+    /// <param name="frequencyPenalty">The scale of the penalty for how often a token is used.
+    /// Should generally be between 0 and 1, although negative numbers are allowed to encourage token reuse.</param>
+    /// <param name="logProbabilities">Include the log probabilities on the logProbabilities most likely tokens,
+    /// which can be found in <see cref="CompletionResult.Completions"/> -> <see cref="Choice.LogProbabilities"/>.
+    /// So for example, if logProbabilities is 10, the API will return a list of the 10 most likely tokens.
+    /// If logProbabilities is supplied, the API will always return the logProbabilities of the sampled token,
+    /// so there may be up to logProbabilities+1 elements in the response.</param>
+    /// <param name="echo">Echo back the prompt in addition to the completion.</param>
+    /// <param name="stopSequences">One or more sequences where the API will stop generating further tokens.
+    /// The returned text will not contain the stop sequence.</param>
+    /// <param name="model">Optional, <see cref="Model"/> to use when calling the API.
+    /// Defaults to <see cref="Model.Davinci"/>.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>An async enumerable with each of the results as they come in.
+    /// See <see href="https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-8#asynchronous-streams">the C# docs</see>
+    /// for more details on how to consume an async enumerable.</returns>
+    IAsyncEnumerable<CompletionResult> StreamCompletionEnumerableAsync(
+        string prompt = null,
+        IEnumerable<string> prompts = null,
+        string suffix = null,
+        int? maxTokens = null,
+        double? temperature = null,
+        double? topP = null,
+        int? numOutputs = null,
+        double? presencePenalty = null,
+        double? frequencyPenalty = null,
+        int? logProbabilities = null,
+        bool? echo = null,
+        IEnumerable<string> stopSequences = null,
+        Model model = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Ask the API to complete the prompt(s) using the specified request, and stream the results as they come in.<br/>
+    /// If you are not using C# 8 supporting IAsyncEnumerable{T} or if you are using the .NET Framework,
+    /// you may need to use <see cref="StreamCompletionAsync(CompletionRequest, Action{CompletionResult}, CancellationToken)"/> instead.
+    /// </summary>
+    /// <param name="completionRequest">The request to send to the API.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>An async enumerable with each of the results as they come in.
+    /// See <seealso href="https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-8#asynchronous-streams"/>
+    /// for more details on how to consume an async enumerable.</returns>
+    /// <exception cref="HttpRequestException">Raised when the HTTP request fails</exception>
+    IAsyncEnumerable<CompletionResult> StreamCompletionEnumerableAsync(CompletionRequest completionRequest,
+        CancellationToken cancellationToken = default);
+}

--- a/OpenAI-DotNet/Edits/EditsEndpoint.cs
+++ b/OpenAI-DotNet/Edits/EditsEndpoint.cs
@@ -9,7 +9,7 @@ namespace OpenAI.Edits
     /// Given a prompt and an instruction, the model will return an edited version of the prompt.<br/>
     /// <see href="https://platform.openai.com/docs/api-reference/edits"/>
     /// </summary>
-    public sealed class EditsEndpoint : BaseEndPoint
+    public sealed class EditsEndpoint : BaseEndPoint, IEditsEndpoint
     {
         /// <inheritdoc />
         public EditsEndpoint(OpenAIClient api) : base(api) { }

--- a/OpenAI-DotNet/Edits/IEditsEndpoint.cs
+++ b/OpenAI-DotNet/Edits/IEditsEndpoint.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading.Tasks;
+using OpenAI.Models;
+
+namespace OpenAI.Edits;
+
+public interface IEditsEndpoint
+{
+    /// <summary>
+    /// Creates a new edit for the provided input, instruction, and parameters
+    /// </summary>
+    /// <param name="input">The input text to use as a starting point for the edit.</param>
+    /// <param name="instruction">The instruction that tells the model how to edit the prompt.</param>
+    /// <param name="editCount">How many edits to generate for the input and instruction.</param>
+    /// <param name="temperature">
+    /// What sampling temperature to use. Higher values means the model will take more risks.
+    /// Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.
+    /// We generally recommend altering this or top_p but not both.
+    /// </param>
+    /// <param name="topP">
+    /// An alternative to sampling with temperature, called nucleus sampling, where the model considers the
+    /// results of the tokens with top_p probability mass.
+    /// So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+    /// We generally recommend altering this or temperature but not both.
+    /// </param>
+    /// <param name="model">ID of the model to use. Defaults to text-davinci-edit-001.</param>
+    /// <returns>The top edit result choice.</returns>
+    Task<string> CreateEditAsync(
+        string input,
+        string instruction,
+        int? editCount,
+        double? temperature,
+        double? topP,
+        Model model = null);
+
+    /// <summary>
+    /// Creates a new edit for the provided input, instruction, and parameters
+    /// </summary>
+    /// <param name="request"><see cref="EditRequest"/></param>
+    /// <returns><see cref="EditResponse"/></returns>
+    Task<EditResponse> CreateEditAsync(EditRequest request);
+}

--- a/OpenAI-DotNet/Embeddings/EmbeddingsEndpoint.cs
+++ b/OpenAI-DotNet/Embeddings/EmbeddingsEndpoint.cs
@@ -10,7 +10,7 @@ namespace OpenAI.Embeddings
     /// Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.<br/>
     /// <see href="https://platform.openai.com/docs/guides/embeddings"/>
     /// </summary>
-    public sealed class EmbeddingsEndpoint : BaseEndPoint
+    public sealed class EmbeddingsEndpoint : BaseEndPoint, IEmbeddingsEndpoint
     {
         /// <inheritdoc />
         public EmbeddingsEndpoint(OpenAIClient api) : base(api) { }

--- a/OpenAI-DotNet/Embeddings/IEmbeddingsEndpoint.cs
+++ b/OpenAI-DotNet/Embeddings/IEmbeddingsEndpoint.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using OpenAI.Models;
+
+namespace OpenAI.Embeddings;
+
+public interface IEmbeddingsEndpoint
+{
+    /// <summary>
+    /// Creates an embedding vector representing the input text.
+    /// </summary>
+    /// <param name="input">
+    /// Input text to get embeddings for, encoded as a string or array of tokens.
+    /// To get embeddings for multiple inputs in a single request, pass an array of strings or array of token arrays.
+    /// Each input must not exceed 8192 tokens in length.
+    /// </param>
+    /// <param name="model">
+    /// ID of the model to use.
+    /// Defaults to: text-embedding-ada-002
+    /// </param>
+    /// <param name="user">
+    /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    /// </param>
+    /// <returns><see cref="EmbeddingsResponse"/></returns>
+    Task<EmbeddingsResponse> CreateEmbeddingAsync(string input, Model model = null, string user = null);
+
+    /// <summary>
+    /// Creates an embedding vector representing the input text.
+    /// </summary>
+    /// <param name="input">
+    /// Input text to get embeddings for, encoded as a string or array of tokens.
+    /// To get embeddings for multiple inputs in a single request, pass an array of strings or array of token arrays.
+    /// Each input must not exceed 8192 tokens in length.
+    /// </param>
+    /// <param name="model">
+    /// ID of the model to use.
+    /// Defaults to: text-embedding-ada-002
+    /// </param>
+    /// <param name="user">
+    /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    /// </param>
+    /// <returns><see cref="EmbeddingsResponse"/></returns>
+    Task<EmbeddingsResponse> CreateEmbeddingAsync(IEnumerable<string> input, Model model = null, string user = null);
+
+    /// <summary>
+    /// Creates an embedding vector representing the input text.
+    /// </summary>
+    /// <returns><see cref="EmbeddingsResponse"/></returns>
+    Task<EmbeddingsResponse> CreateEmbeddingAsync(EmbeddingsRequest request);
+}

--- a/OpenAI-DotNet/Files/FilesEndpoint.cs
+++ b/OpenAI-DotNet/Files/FilesEndpoint.cs
@@ -14,7 +14,7 @@ namespace OpenAI.Files
     /// Files are used to upload documents that can be used with features like Fine-tuning.<br/>
     /// <see href="https://platform.openai.com/docs/api-reference/fine-tunes"/>
     /// </summary>
-    public sealed class FilesEndpoint : BaseEndPoint
+    public sealed class FilesEndpoint : BaseEndPoint, IFilesEndpoint
     {
         private class FilesList
         {

--- a/OpenAI-DotNet/Files/IFilesEndpoint.cs
+++ b/OpenAI-DotNet/Files/IFilesEndpoint.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenAI.Files;
+
+public interface IFilesEndpoint
+{
+    /// <summary>
+    /// Returns a list of files that belong to the user's organization.
+    /// </summary>
+    /// <returns>List of <see cref="FileData"/>.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<IReadOnlyList<FileData>> ListFilesAsync();
+
+    /// <summary>
+    /// Upload a file that contains document(s) to be used across various endpoints/features.
+    /// Currently, the size of all the files uploaded by one organization can be up to 1 GB.
+    /// Please contact us if you need to increase the storage limit.
+    /// </summary>
+    /// <param name="filePath">
+    /// Local file path to upload.
+    /// </param>
+    /// <param name="purpose">
+    /// The intended purpose of the uploaded documents.
+    /// If the purpose is set to "fine-tune", each line is a JSON record with "prompt" and "completion"
+    /// fields representing your training examples.
+    /// </param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns><see cref="FileData"/>.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<FileData> UploadFileAsync(string filePath, string purpose, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Upload a file that contains document(s) to be used across various endpoints/features.
+    /// Currently, the size of all the files uploaded by one organization can be up to 1 GB.
+    /// Please contact us if you need to increase the storage limit.
+    /// </summary>
+    /// <param name="request"><see cref="FileUploadRequest"/>.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns><see cref="FileData"/>.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<FileData> UploadFileAsync(FileUploadRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete a file.
+    /// </summary>
+    /// <param name="fileId">The ID of the file to use for this request</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>True, if file was successfully deleted.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<bool> DeleteFileAsync(string fileId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns information about a specific file.
+    /// </summary>
+    /// <param name="fileId">The ID of the file to use for this request.</param>
+    /// <returns></returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<FileData> GetFileInfoAsync(string fileId);
+
+    /// <summary>
+    /// Downloads the specified file.
+    /// </summary>
+    /// <param name="fileId">The file id to download.</param>
+    /// <param name="directory">The directory to download the file into.</param>
+    /// <param name="deleteCachedFile">Optional, delete cached file. Default is false.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/></param>
+    /// <returns>The full path of the downloaded file.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<string> DownloadFileAsync(string fileId, string directory, bool deleteCachedFile = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Downloads the specified file.
+    /// </summary>
+    /// <param name="fileData"><see cref="FileData"/> to download.</param>
+    /// <param name="directory">The directory to download the file into.</param>
+    /// <param name="deleteCachedFile">Optional, delete cached file. Default is false.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/></param>
+    /// <returns>The full path of the downloaded file.</returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    Task<string> DownloadFileAsync(FileData fileData, string directory, bool deleteCachedFile = false, CancellationToken cancellationToken = default);
+}

--- a/OpenAI-DotNet/FineTuning/FineTuningEndpoint.cs
+++ b/OpenAI-DotNet/FineTuning/FineTuningEndpoint.cs
@@ -16,7 +16,7 @@ namespace OpenAI.FineTuning
     /// Manage fine-tuning jobs to tailor a model to your specific training data.<br/>
     /// <see href="https://platform.openai.com/docs/guides/fine-tuning"/>
     /// </summary>
-    public sealed class FineTuningEndpoint : BaseEndPoint
+    public sealed class FineTuningEndpoint : BaseEndPoint, IFineTuningEndpoint
     {
         private class FineTuneList
         {

--- a/OpenAI-DotNet/FineTuning/IFineTuningEndpoint.cs
+++ b/OpenAI-DotNet/FineTuning/IFineTuningEndpoint.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenAI.FineTuning;
+
+public interface IFineTuningEndpoint
+{
+    /// <summary>
+    /// Creates a job that fine-tunes a specified model from a given dataset.
+    /// Response includes details of the enqueued job including job status and
+    /// the name of the fine-tuned models once complete.
+    /// </summary>
+    /// <param name="jobRequest"><see cref="CreateFineTuneJobRequest"/>.</param>
+    /// <returns><see cref="FineTuneJob"/>.</returns>
+    /// <exception cref="HttpRequestException">.</exception>
+    Task<FineTuneJob> CreateFineTuneJobAsync(CreateFineTuneJobRequest jobRequest);
+
+    /// <summary>
+    /// List your organization's fine-tuning jobs.
+    /// </summary>
+    /// <returns>List of <see cref="FineTuneJob"/>s.</returns>
+    /// <exception cref="HttpRequestException">.</exception>
+    Task<IReadOnlyList<FineTuneJob>> ListFineTuneJobsAsync();
+
+    /// <summary>
+    /// Gets info about the fine-tune job.
+    /// </summary>
+    /// <param name="jobId"><see cref="FineTuneJob.Id"/>.</param>
+    /// <returns><see cref="FineTuneJobResponse"/>.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<FineTuneJob> RetrieveFineTuneJobInfoAsync(string jobId);
+
+    /// <summary>
+    /// Immediately cancel a fine-tune job.
+    /// </summary>
+    /// <param name="jobId"><see cref="FineTuneJob.Id"/> to cancel.</param>
+    /// <returns><see cref="FineTuneJobResponse"/>.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<bool> CancelFineTuneJobAsync(string jobId);
+
+    /// <summary>
+    /// Get fine-grained status updates for a fine-tune job.
+    /// </summary>
+    /// <param name="jobId"><see cref="FineTuneJob.Id"/>.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>List of events for <see cref="FineTuneJob"/>.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<IReadOnlyList<Event>> ListFineTuneEventsAsync(string jobId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stream the fine-grained status updates for a fine-tune job.
+    /// </summary>
+    /// <param name="jobId"><see cref="FineTuneJob.Id"/>.</param>
+    /// <param name="fineTuneEventCallback">The event callback handler.</param>
+    /// <param name="cancelJob">Optional, Cancel the job if streaming is aborted. Default is false.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <exception cref="HttpRequestException"></exception>
+    Task StreamFineTuneEventsAsync(string jobId, Action<Event> fineTuneEventCallback, bool cancelJob = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stream the fine-grained status updates for a fine-tune job.
+    /// </summary>
+    /// <param name="jobId"><see cref="FineTuneJob.Id"/>.</param>
+    /// <param name="cancelJob">Optional, Cancel the job if streaming is aborted. Default is false.</param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <exception cref="HttpRequestException"></exception>
+    IAsyncEnumerable<Event> StreamFineTuneEventsEnumerableAsync(string jobId, bool cancelJob = false, CancellationToken cancellationToken = default);
+}

--- a/OpenAI-DotNet/IOpenAIClient.cs
+++ b/OpenAI-DotNet/IOpenAIClient.cs
@@ -1,0 +1,86 @@
+﻿using OpenAI.Audio;
+using OpenAI.Chat;
+using OpenAI.Completions;
+using OpenAI.Edits;
+using OpenAI.Embeddings;
+using OpenAI.Files;
+using OpenAI.FineTuning;
+using OpenAI.Images;
+using OpenAI.Models;
+using OpenAI.Moderations;
+
+namespace OpenAI;
+
+public interface IOpenAIClient
+{
+    /// <summary>
+    /// The API authentication information to use for API calls
+    /// </summary>
+    OpenAIAuthentication OpenAIAuthentication { get; }
+    
+    /// <summary>
+    /// List and describe the various models available in the API.
+    /// You can refer to the Models documentation to understand what <see href="https://platform.openai.com/docs/models"/> are available and the differences between them.<br/>
+    /// <see href="https://platform.openai.com/docs/api-reference/models"/>
+    /// </summary>
+    IModelsEndpoint ModelsEndpoint { get; }
+    
+    /// <summary>
+    /// Text generation is the core function of the API. You give the API a prompt, and it generates a completion.
+    /// The way you “program” the API to do a task is by simply describing the task in plain english or providing
+    /// a few written examples. This simple approach works for a wide range of use cases, including summarization,
+    /// translation, grammar correction, question answering, chatbots, composing emails, and much more
+    /// (see the prompt library for inspiration).<br/>
+    /// <see href="https://platform.openai.com/docs/api-reference/completions"/>
+    /// </summary>
+    ICompletionsEndpoint CompletionsEndpoint { get; }
+    
+    /// <summary>
+    /// Given a chat conversation, the model will return a chat completion response.<br/>
+    /// <see href="https://platform.openai.com/docs/api-reference/chat"/>
+    /// </summary>
+    IChatEndpoint ChatEndpoint { get; }
+    
+    /// <summary>
+    /// Given a prompt and an instruction, the model will return an edited version of the prompt.<br/>
+    /// <see href="https://platform.openai.com/docs/api-reference/edits"/>
+    /// </summary>
+    IEditsEndpoint EditsEndpoint { get; }
+    
+    /// <summary>
+    /// Given a prompt and/or an input image, the model will generate a new image.<br/>
+    /// <see href="https://platform.openai.com/docs/api-reference/images"/>
+    /// </summary>
+    IImagesEndpoint ImagesEndPoint { get; }
+    
+    /// <summary>
+    /// Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.<br/>
+    /// <see href="https://platform.openai.com/docs/guides/embeddings"/>
+    /// </summary>
+    IEmbeddingsEndpoint EmbeddingsEndpoint { get; }
+    
+    /// <summary>
+    /// Transforms audio into text.<br/>
+    /// <see href="https://platform.openai.com/docs/api-reference/audio"/>
+    /// </summary>
+    IAudioEndpoint AudioEndpoint { get; }
+    
+    /// <summary>
+    /// Files are used to upload documents that can be used with features like Fine-tuning.<br/>
+    /// <see href="https://platform.openai.com/docs/api-reference/fine-tunes"/>
+    /// </summary>
+    IFilesEndpoint FilesEndpoint { get; }
+    
+    /// <summary>
+    /// Manage fine-tuning jobs to tailor a model to your specific training data.<br/>
+    /// <see href="https://platform.openai.com/docs/guides/fine-tuning"/>
+    /// </summary>
+    IFineTuningEndpoint FineTuningEndpoint { get; }
+    
+    /// <summary>
+    /// The moderation endpoint is a tool you can use to check whether content complies with OpenAI's content policy.
+    /// Developers can thus identify content that our content policy prohibits and take action, for instance by filtering it.<br/>
+    /// <see href="https://platform.openai.com/docs/api-reference/moderations"/>
+    /// </summary>
+    IModerationsEndpoint ModerationsEndpoint { get; }
+}

--- a/OpenAI-DotNet/Images/IImagesEndpoint.cs
+++ b/OpenAI-DotNet/Images/IImagesEndpoint.cs
@@ -1,0 +1,138 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenAI.Images;
+
+public interface IImagesEndpoint
+{
+    /// <summary>
+    /// Creates an image given a prompt.
+    /// </summary>
+    /// <param name="prompt">
+    /// A text description of the desired image(s). The maximum length is 1000 characters.
+    /// </param>
+    /// <param name="numberOfResults">
+    /// The number of images to generate. Must be between 1 and 10.
+    /// </param>
+    /// <param name="size">
+    /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+    /// </param>
+    /// <param name="user">
+    /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    /// </param>
+    /// <param name="responseFormat">
+    /// The format in which the generated images are returned. Must be one of url or b64_json.
+    /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Optional, <see cref="CancellationToken"/>.
+    /// </param>
+    /// <returns>A list of generated texture urls to download.</returns>
+    Task<IReadOnlyList<string>> GenerateImageAsync(
+        string prompt,
+        int numberOfResults = 1,
+        ImageSize size = ImageSize.Large,
+        string user = null,
+        ResponseFormat responseFormat = ResponseFormat.Url,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates an image given a prompt.
+    /// </summary>
+    /// <param name="request"><see cref="ImageGenerationRequest"/></param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>A list of generated texture urls to download.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<IReadOnlyList<string>> GenerateImageAsync(ImageGenerationRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates an edited or extended image given an original image and a prompt.
+    /// </summary>
+    /// <param name="image">
+    /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
+    /// If mask is not provided, image must have transparency, which will be used as the mask.
+    /// </param>
+    /// <param name="mask">
+    /// An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where image should be edited.
+    /// Must be a valid PNG file, less than 4MB, and have the same dimensions as image.
+    /// </param>
+    /// <param name="prompt">
+    /// A text description of the desired image(s). The maximum length is 1000 characters.
+    /// </param>
+    /// <param name="numberOfResults">
+    /// The number of images to generate. Must be between 1 and 10.
+    /// </param>
+    /// <param name="size">
+    /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+    /// </param>
+    /// <param name="responseFormat">
+    /// The format in which the generated images are returned. Must be one of url or b64_json.
+    /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+    /// </param>
+    /// <param name="user">
+    /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    /// </param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>A list of generated texture urls to download.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<IReadOnlyList<string>> CreateImageEditAsync(
+        string image,
+        string mask,
+        string prompt,
+        int numberOfResults = 1,
+        ImageSize size = ImageSize.Large,
+        ResponseFormat responseFormat = ResponseFormat.Url,
+        string user = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates an edited or extended image given an original image and a prompt.
+    /// </summary>
+    /// <param name="request"><see cref="ImageEditRequest"/></param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>A list of generated texture urls to download.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<IReadOnlyList<string>> CreateImageEditAsync(ImageEditRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a variation of a given image.
+    /// </summary>
+    /// <param name="imagePath">
+    /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
+    /// If mask is not provided, image must have transparency, which will be used as the mask.
+    /// </param>
+    /// <param name="numberOfResults">
+    /// The number of images to generate. Must be between 1 and 10.
+    /// </param>
+    /// <param name="size">
+    /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+    /// </param>
+    /// <param name="responseFormat">
+    /// The format in which the generated images are returned. Must be one of url or b64_json.
+    /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+    /// </param>
+    /// <param name="user">
+    /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    /// </param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>A list of generated texture urls to download.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<IReadOnlyList<string>> CreateImageVariationAsync(
+        string imagePath,
+        int numberOfResults = 1,
+        ImageSize size = ImageSize.Large,
+        ResponseFormat responseFormat = ResponseFormat.Url,
+        string user = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a variation of a given image.
+    /// </summary>
+    /// <param name="request"><see cref="ImageVariationRequest"/></param>
+    /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+    /// <returns>A list of generated texture urls to download.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<IReadOnlyList<string>> CreateImageVariationAsync(ImageVariationRequest request, CancellationToken cancellationToken = default);
+}

--- a/OpenAI-DotNet/Images/ImagesEndpoint.cs
+++ b/OpenAI-DotNet/Images/ImagesEndpoint.cs
@@ -13,7 +13,7 @@ namespace OpenAI.Images
     /// Given a prompt and/or an input image, the model will generate a new image.<br/>
     /// <see href="https://platform.openai.com/docs/api-reference/images"/>
     /// </summary>
-    public sealed class ImagesEndpoint : BaseEndPoint
+    public sealed class ImagesEndpoint : BaseEndPoint, IImagesEndpoint
     {
         /// <inheritdoc />
         internal ImagesEndpoint(OpenAIClient api) : base(api) { }

--- a/OpenAI-DotNet/Models/IModelsEndpoint.cs
+++ b/OpenAI-DotNet/Models/IModelsEndpoint.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace OpenAI.Models;
+
+public interface IModelsEndpoint
+{
+    /// <summary>
+    /// List all models via the API
+    /// </summary>
+    /// <returns>Asynchronously returns the list of all <see cref="Model"/>s</returns>
+    /// <exception cref="HttpRequestException">Raised when the HTTP request fails</exception>
+    Task<IReadOnlyList<Model>> GetModelsAsync();
+
+    /// <summary>
+    /// Get the details about a particular Model from the API
+    /// </summary>
+    /// <param name="id">The id/name of the model to get more details about</param>
+    /// <returns>Asynchronously returns the <see cref="Model"/> with all available properties</returns>
+    /// <exception cref="HttpRequestException">Raised when the HTTP request fails</exception>
+    Task<Model> GetModelDetailsAsync(string id);
+
+    /// <summary>
+    /// Delete a fine-tuned model. You must have the Owner role in your organization.
+    /// </summary>
+    /// <param name="modelId">The <see cref="Model"/> to delete.</param>
+    /// <returns>True, if fine-tuned model was successfully deleted.</returns>
+    /// <exception cref="HttpRequestException"></exception>
+    Task<bool> DeleteFineTuneModelAsync(string modelId);
+}

--- a/OpenAI-DotNet/Models/ModelsEndpoint.cs
+++ b/OpenAI-DotNet/Models/ModelsEndpoint.cs
@@ -13,7 +13,7 @@ namespace OpenAI.Models
     /// You can refer to the Models documentation to understand what <see href="https://platform.openai.com/docs/models"/> are available and the differences between them.<br/>
     /// <see href="https://platform.openai.com/docs/api-reference/models"/>
     /// </summary>
-    public sealed class ModelsEndpoint : BaseEndPoint
+    public sealed class ModelsEndpoint : BaseEndPoint, IModelsEndpoint
     {
         private class ModelsList
         {

--- a/OpenAI-DotNet/Moderations/IModerationsEndpoint.cs
+++ b/OpenAI-DotNet/Moderations/IModerationsEndpoint.cs
@@ -1,0 +1,31 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using OpenAI.Models;
+
+namespace OpenAI.Moderations;
+
+public interface IModerationsEndpoint
+{
+    /// <summary>
+    /// Classifies if text violates OpenAI's Content Policy.
+    /// </summary>
+    /// <param name="input">
+    /// The input text to classify.
+    /// </param>
+    /// <param name="model">The default is text-moderation-latest which will be automatically upgraded over time.
+    /// This ensures you are always using our most accurate model.
+    /// If you use text-moderation-stable, we will provide advanced notice before updating the model.
+    /// Accuracy of text-moderation-stable may be slightly lower than for text-moderation-latest.
+    /// </param>
+    /// <returns>
+    /// True, if the text has been flagged by the model as violating OpenAI's content policy.
+    /// </returns>
+    Task<bool> GetModerationAsync(string input, Model model = null);
+
+    /// <summary>
+    /// Classifies if text violates OpenAI's Content Policy
+    /// </summary>
+    /// <param name="request"><see cref="ModerationsRequest"/></param>
+    /// <exception cref="HttpRequestException">Raised when the HTTP request fails</exception>
+    Task<ModerationsResponse> CreateModerationAsync(ModerationsRequest request);
+}

--- a/OpenAI-DotNet/Moderations/ModerationsEndpoint.cs
+++ b/OpenAI-DotNet/Moderations/ModerationsEndpoint.cs
@@ -12,7 +12,7 @@ namespace OpenAI.Moderations
     /// Developers can thus identify content that our content policy prohibits and take action, for instance by filtering it.<br/>
     /// <see href="https://platform.openai.com/docs/api-reference/moderations"/>
     /// </summary>
-    public sealed class ModerationsEndpoint : BaseEndPoint
+    public sealed class ModerationsEndpoint : BaseEndPoint, IModerationsEndpoint
     {
         /// <inheritdoc />
         public ModerationsEndpoint(OpenAIClient api) : base(api) { }

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -160,4 +160,7 @@ Version 4.4.0
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+  </ItemGroup>
 </Project>

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -20,7 +20,7 @@ namespace OpenAI
     /// <summary>
     /// Entry point to the OpenAI API, handling auth and allowing access to the various API endpoints
     /// </summary>
-    public sealed class OpenAIClient
+    public sealed class OpenAIClient : IOpenAIClient
     {
         /// <summary>
         /// Creates a new entry point to the OpenAPI API, handling auth and allowing access to the various API endpoints
@@ -142,7 +142,7 @@ namespace OpenAI
         /// You can refer to the Models documentation to understand what <see href="https://platform.openai.com/docs/models"/> are available and the differences between them.<br/>
         /// <see href="https://platform.openai.com/docs/api-reference/models"/>
         /// </summary>
-        public ModelsEndpoint ModelsEndpoint { get; }
+        public IModelsEndpoint ModelsEndpoint { get; }
 
         /// <summary>
         /// Text generation is the core function of the API. You give the API a prompt, and it generates a completion.
@@ -152,55 +152,55 @@ namespace OpenAI
         /// (see the prompt library for inspiration).<br/>
         /// <see href="https://platform.openai.com/docs/api-reference/completions"/>
         /// </summary>
-        public CompletionsEndpoint CompletionsEndpoint { get; }
+        public ICompletionsEndpoint CompletionsEndpoint { get; }
 
         /// <summary>
         /// Given a chat conversation, the model will return a chat completion response.<br/>
         /// <see href="https://platform.openai.com/docs/api-reference/chat"/>
         /// </summary>
-        public ChatEndpoint ChatEndpoint { get; }
+        public IChatEndpoint ChatEndpoint { get; }
 
         /// <summary>
         /// Given a prompt and an instruction, the model will return an edited version of the prompt.<br/>
         /// <see href="https://platform.openai.com/docs/api-reference/edits"/>
         /// </summary>
-        public EditsEndpoint EditsEndpoint { get; }
+        public IEditsEndpoint EditsEndpoint { get; }
 
         /// <summary>
         /// Given a prompt and/or an input image, the model will generate a new image.<br/>
         /// <see href="https://platform.openai.com/docs/api-reference/images"/>
         /// </summary>
-        public ImagesEndpoint ImagesEndPoint { get; }
+        public IImagesEndpoint ImagesEndPoint { get; }
 
         /// <summary>
         /// Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.<br/>
         /// <see href="https://platform.openai.com/docs/guides/embeddings"/>
         /// </summary>
-        public EmbeddingsEndpoint EmbeddingsEndpoint { get; }
+        public IEmbeddingsEndpoint EmbeddingsEndpoint { get; }
 
         /// <summary>
         /// Transforms audio into text.<br/>
         /// <see href="https://platform.openai.com/docs/api-reference/audio"/>
         /// </summary>
-        public AudioEndpoint AudioEndpoint { get; }
+        public IAudioEndpoint AudioEndpoint { get; }
 
         /// <summary>
         /// Files are used to upload documents that can be used with features like Fine-tuning.<br/>
         /// <see href="https://platform.openai.com/docs/api-reference/fine-tunes"/>
         /// </summary>
-        public FilesEndpoint FilesEndpoint { get; }
+        public IFilesEndpoint FilesEndpoint { get; }
 
         /// <summary>
         /// Manage fine-tuning jobs to tailor a model to your specific training data.<br/>
         /// <see href="https://platform.openai.com/docs/guides/fine-tuning"/>
         /// </summary>
-        public FineTuningEndpoint FineTuningEndpoint { get; }
+        public IFineTuningEndpoint FineTuningEndpoint { get; }
 
         /// <summary>
         /// The moderation endpoint is a tool you can use to check whether content complies with OpenAI's content policy.
         /// Developers can thus identify content that our content policy prohibits and take action, for instance by filtering it.<br/>
         /// <see href="https://platform.openai.com/docs/api-reference/moderations"/>
         /// </summary>
-        public ModerationsEndpoint ModerationsEndpoint { get; }
+        public IModerationsEndpoint ModerationsEndpoint { get; }
     }
 }

--- a/OpenAI-DotNet/ServiceCollectionExtensions.cs
+++ b/OpenAI-DotNet/ServiceCollectionExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OpenAI;
+
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the <see cref="IOpenAIClient"/> as a singleton in the <see cref="IServiceCollection"/>
+    /// with the supplied authentication, settings, and HTTP client.
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="openAIAuthentication"></param>
+    /// <param name="clientSettings"></param>
+    /// <param name="client"></param>
+    /// <returns>A reference to this instance after the operation has completed</returns>
+    public static IServiceCollection AddOpenAI(this IServiceCollection services,
+        OpenAIAuthentication openAIAuthentication,
+        OpenAIClientSettings clientSettings,
+        HttpClient client)
+    {
+        return services.AddSingleton<IOpenAIClient>(new OpenAIClient(openAIAuthentication, clientSettings, client));
+    }
+
+    /// <summary>
+    /// Registers the <see cref="IOpenAIClient"/> as a singleton in the <see cref="IServiceCollection"/>
+    /// with the supplied authentication and settings.
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="openAIAuthentication"></param>
+    /// <param name="clientSettings"></param>
+    /// <returns>A reference to this instance after the operation has completed</returns>
+    public static IServiceCollection AddOpenAI(this IServiceCollection services,
+        OpenAIAuthentication openAIAuthentication,
+        OpenAIClientSettings clientSettings) => AddOpenAI(services, openAIAuthentication, clientSettings, null);
+    
+    /// <summary>
+    /// Registers the <see cref="IOpenAIClient"/> as a singleton in the <see cref="IServiceCollection"/>
+    /// using the default authentication and settings.
+    /// </summary>
+    /// <param name="services"></param>
+    /// <returns>A reference to this instance after the operation has completed</returns>
+    public static IServiceCollection AddOpenAI(this IServiceCollection services) => AddOpenAI(services,
+        openAIAuthentication: null,
+        clientSettings: null,
+        client: null);
+}


### PR DESCRIPTION
For issue #93
This adds interfaces for the `OpenAIClient` and all of the "Endpoint" classes. Without this change, mocking the client and endpoints is impossible so it is much more difficult to write unit tests against code that uses these classes.

Additionally added a few extension methods to help the consumers of this library register the `OpenAIClient` as a dependency. These methods register the client as a singleton, which tends to have the best performance, and also follows Microsofts recommendation to make the `HttpClient` a static or singleton variable.