### PR TITLE
Bump default Azure API version to 2023-05-15

### DIFF
--- a/OpenAI-DotNet/OpenAIClientSettings.cs
+++ b/OpenAI-DotNet/OpenAIClientSettings.cs
@@ -10,7 +10,7 @@ namespace OpenAI
         internal const string OpenAIDomain = "api.openai.com";
         internal const string DefaultOpenAIApiVersion = "v1";
         internal const string AzureOpenAIDomain = "openai.azure.com";
-        internal const string DefaultAzureApiVersion = "2022-12-01";
+        internal const string DefaultAzureApiVersion = "2023-05-15";
 
         /// <summary>
         /// Creates a new instance of <see cref="OpenAIClientSettings"/> for use with OpenAI.
@@ -67,7 +67,7 @@ namespace OpenAI
         /// The name of your model deployment. You're required to first deploy a model before you can make calls.
         /// </param>
         /// <param name="apiVersion">
-        /// Optional, defaults to 2022-12-01
+        /// Optional, defaults to 2023-05-15
         /// </param>
         /// <param name="useActiveDirectoryAuthentication">
         /// Optional, set to true if you want to use Azure Active Directory for Authentication.


### PR DESCRIPTION
It seems that new deployments in Azure OpenAI are not available with the previous default Azure version anymore.

When diffing the [old version swagger spec](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2022-12-01/inference.json) with [the new swagger spec](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2023-05-15/inference.json), the only differences are a new version number and that the chat completion endpoints were added. It seems like they weren't part of the older (probably preview) API.

This fixes #112 