### PR TITLE
Allow usage in a blazor application

### DIFF
--- a/OpenAI-DotNet/Extensions/ResponseExtensions.cs
+++ b/OpenAI-DotNet/Extensions/ResponseExtensions.cs
@@ -22,8 +22,15 @@ namespace OpenAI.Extensions
                 response.Organization = headers.GetValues(Organization).FirstOrDefault();
             }
 
-            response.ProcessingTime = TimeSpan.FromMilliseconds(double.Parse(headers.GetValues(ProcessingTime).First()));
-            response.RequestId = headers.GetValues(RequestId).FirstOrDefault();
+            if (headers.Contains(ProcessingTime))
+            {
+                response.ProcessingTime = TimeSpan.FromMilliseconds(double.Parse(headers.GetValues(ProcessingTime).First()));
+            }
+
+            if (headers.Contains(RequestId))
+            {
+                response.RequestId = headers.GetValues(RequestId).FirstOrDefault();
+            }
         }
 
         internal static async Task<string> ReadAsStringAsync(this HttpResponseMessage response, CancellationToken cancellationToken = default, [CallerMemberName] string methodName = null)

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -33,6 +33,7 @@ namespace OpenAI
         /// <param name="clientSettings">
         /// Optional, <see cref="OpenAIClientSettings"/> for specifying OpenAI deployments to Azure or proxy domain.
         /// </param>
+        /// <param name="client">A <see cref="HttpClient"/>.</param>
         /// <exception cref="AuthenticationException">Raised when authentication details are missing or invalid.</exception>
         public OpenAIClient(OpenAIAuthentication openAIAuthentication = null, OpenAIClientSettings clientSettings = null, HttpClient client = null)
         {

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -33,27 +33,8 @@ namespace OpenAI
         /// <param name="clientSettings">
         /// Optional, <see cref="OpenAIClientSettings"/> for specifying OpenAI deployments to Azure or proxy domain.
         /// </param>
-        /// <param name="client">A <see cref="HttpClient"/>.</param>
         /// <exception cref="AuthenticationException">Raised when authentication details are missing or invalid.</exception>
-        public OpenAIClient(OpenAIAuthentication openAIAuthentication, OpenAIClientSettings clientSettings, HttpClient client)
-            : this(openAIAuthentication, clientSettings)
-        {
-            Client = SetupClient(client);
-        }
-
-        /// <summary>
-        /// Creates a new entry point to the OpenAPI API, handling auth and allowing access to the various API endpoints
-        /// </summary>
-        /// <param name="openAIAuthentication">
-        /// The API authentication information to use for API calls,
-        /// or <see langword="null"/> to attempt to use the <see cref="OpenAI.OpenAIAuthentication.Default"/>,
-        /// potentially loading from environment vars or from a config file.
-        /// </param>
-        /// <param name="clientSettings">
-        /// Optional, <see cref="OpenAIClientSettings"/> for specifying OpenAI deployments to Azure or proxy domain.
-        /// </param>
-        /// <exception cref="AuthenticationException">Raised when authentication details are missing or invalid.</exception>
-        public OpenAIClient(OpenAIAuthentication openAIAuthentication = null, OpenAIClientSettings clientSettings = null)
+        public OpenAIClient(OpenAIAuthentication openAIAuthentication = null, OpenAIClientSettings clientSettings = null, HttpClient client = null)
         {
             OpenAIAuthentication = openAIAuthentication ?? OpenAIAuthentication.Default;
             OpenAIClientSettings = clientSettings ?? OpenAIClientSettings.Default;
@@ -63,7 +44,7 @@ namespace OpenAI
                 throw new AuthenticationException("You must provide API authentication.  Please refer to https://github.com/RageAgainstThePixel/OpenAI-DotNet#authentication for details.");
             }
 
-            Client = SetupClient();
+            Client = SetupClient(client);
             JsonSerializationOptions = new JsonSerializerOptions
             {
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,


### PR DESCRIPTION
Even when using the constructor which you pass a HttpClient into, constructing a new OpenAIClient ends up calling SetupClient twice, once where it will create a client, then again with the supplied client.

This is a problem in blazor, as blazor does not support pooled connection lifetime settings.

Error from blazor:
![image](https://github.com/RageAgainstThePixel/OpenAI-DotNet/assets/13741016/bf19858d-5e8b-42a9-a6a7-136f95228f3c)

With this calling code:
```csharp
var openAiClient = new OpenAIClient(apiKey, OpenAIClientSettings.Default, new HttpClient());
```

After making the constructor change, the client is able to be constructed correctly, however when making a request to OpenAi, there is a deserialization issue.  The headers that the fetch api is able to read are restricted to those which are allowed by OpenAI's CORS policy.  They do not allow for reading the headers:
```
        private const string Organization = "Openai-Organization";
        private const string RequestId = "X-Request-ID";
        private const string ProcessingTime = "Openai-Processing-Ms";
```

Since those are informational, this change also allows for them to be unset in the headers, allowing deserialization to proceed.  I have sucessfully made a call to the chat api inside a blazor wasm project with this code
