### PR TITLE
OpenAI-DotNet 7.0.2

### DIFF
--- a/OpenAI-DotNet/Extensions/ResponseExtensions.cs
+++ b/OpenAI-DotNet/Extensions/ResponseExtensions.cs
@@ -22,8 +22,15 @@ namespace OpenAI.Extensions
                 response.Organization = headers.GetValues(Organization).FirstOrDefault();
             }
 
-            response.ProcessingTime = TimeSpan.FromMilliseconds(double.Parse(headers.GetValues(ProcessingTime).First()));
-            response.RequestId = headers.GetValues(RequestId).FirstOrDefault();
+            if (headers.Contains(ProcessingTime))
+            {
+                response.ProcessingTime = TimeSpan.FromMilliseconds(double.Parse(headers.GetValues(ProcessingTime).First()));
+            }
+
+            if (headers.Contains(RequestId))
+            {
+                response.RequestId = headers.GetValues(RequestId).FirstOrDefault();
+            }
         }
 
         internal static async Task<string> ReadAsStringAsync(this HttpResponseMessage response, CancellationToken cancellationToken = default, [CallerMemberName] string methodName = null)

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -17,8 +17,11 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <RepositoryUrl>https://github.com/RageAgainstThePixel/OpenAI-DotNet</RepositoryUrl>
     <PackageTags>OpenAI, AI, ML, API, gpt-4, gpt-3.5-tubo, gpt-3, chatGPT, chat-gpt, gpt-2, gpt</PackageTags>
     <Title>OpenAI API</Title>
-    <Version>7.0.1</Version>
-    <PackageReleaseNotes>Version 7.0.1
+    <Version>7.0.2</Version>
+    <PackageReleaseNotes>Version 7.0.2
+- Only set response header properties if they exist
+- Remove OpenAIClient.ctr overload
+Version 7.0.1
 - Fixed streaming chat functions
 Version 7.0.0
 - Added function calling to chat models

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -35,25 +35,7 @@ namespace OpenAI
         /// </param>
         /// <param name="client">A <see cref="HttpClient"/>.</param>
         /// <exception cref="AuthenticationException">Raised when authentication details are missing or invalid.</exception>
-        public OpenAIClient(OpenAIAuthentication openAIAuthentication, OpenAIClientSettings clientSettings, HttpClient client)
-            : this(openAIAuthentication, clientSettings)
-        {
-            Client = SetupClient(client);
-        }
-
-        /// <summary>
-        /// Creates a new entry point to the OpenAPI API, handling auth and allowing access to the various API endpoints
-        /// </summary>
-        /// <param name="openAIAuthentication">
-        /// The API authentication information to use for API calls,
-        /// or <see langword="null"/> to attempt to use the <see cref="OpenAI.OpenAIAuthentication.Default"/>,
-        /// potentially loading from environment vars or from a config file.
-        /// </param>
-        /// <param name="clientSettings">
-        /// Optional, <see cref="OpenAIClientSettings"/> for specifying OpenAI deployments to Azure or proxy domain.
-        /// </param>
-        /// <exception cref="AuthenticationException">Raised when authentication details are missing or invalid.</exception>
-        public OpenAIClient(OpenAIAuthentication openAIAuthentication = null, OpenAIClientSettings clientSettings = null)
+        public OpenAIClient(OpenAIAuthentication openAIAuthentication = null, OpenAIClientSettings clientSettings = null, HttpClient client = null)
         {
             OpenAIAuthentication = openAIAuthentication ?? OpenAIAuthentication.Default;
             OpenAIClientSettings = clientSettings ?? OpenAIClientSettings.Default;
@@ -63,7 +45,7 @@ namespace OpenAI
                 throw new AuthenticationException("You must provide API authentication.  Please refer to https://github.com/RageAgainstThePixel/OpenAI-DotNet#authentication for details.");
             }
 
-            Client = SetupClient();
+            Client = SetupClient(client);
             JsonSerializationOptions = new JsonSerializerOptions
             {
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,


### PR DESCRIPTION
- Only set response header properties if they exist
- Remove OpenAIClient.ctr overload