### PR TITLE
Use exception handling for responses

### DIFF
--- a/OpenAI-DotNet/Assistants/AssistantsEndpoint.cs
+++ b/OpenAI-DotNet/Assistants/AssistantsEndpoint.cs
@@ -1,6 +1,7 @@
 using OpenAI.Extensions;
 using OpenAI.Files;
 using System;
+using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,7 +22,7 @@ namespace OpenAI.Assistants
         /// <returns><see cref="ListResponse{Assistant}"/></returns>
         public async Task<ListResponse<AssistantResponse>> ListAssistantsAsync(ListQuery query = null, CancellationToken cancellationToken = default)
         {
-            var response = await client.Client.GetAsync(GetUrl(queryParameters: query), cancellationToken).ConfigureAwait(false);
+            var response = await client.Client.GetResponseAsync(GetUrl(queryParameters: query), HttpMethod.Get, cancellationToken: cancellationToken);
             var responseAsString = await response.ReadAsStringAsync(EnableDebug, cancellationToken).ConfigureAwait(false);
             return response.Deserialize<ListResponse<AssistantResponse>>(responseAsString, client);
         }

--- a/OpenAI-DotNet/Audio/AudioEndpoint.cs
+++ b/OpenAI-DotNet/Audio/AudioEndpoint.cs
@@ -43,7 +43,7 @@ namespace OpenAI.Audio
         {
             var jsonContent = JsonSerializer.Serialize(request, OpenAIClient.JsonSerializationOptions).ToJsonStringContent(EnableDebug);
             var response = await client.Client.PostAsync(GetUrl("/speech"), jsonContent, cancellationToken).ConfigureAwait(false);
-            await response.CheckResponseAsync(cancellationToken).ConfigureAwait(false);
+            await response.ThrowApiExceptionIfUnsuccessfulAsync(cancellationToken).ConfigureAwait(false);
             await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             await using var memoryStream = new MemoryStream();
             int bytesRead;

--- a/OpenAI-DotNet/Chat/ChatEndpoint.cs
+++ b/OpenAI-DotNet/Chat/ChatEndpoint.cs
@@ -50,7 +50,7 @@ namespace OpenAI.Chat
             using var request = new HttpRequestMessage(HttpMethod.Post, GetUrl("/completions"));
             request.Content = jsonContent;
             var response = await client.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-            await response.CheckResponseAsync(cancellationToken).ConfigureAwait(false);
+            await response.ThrowApiExceptionIfUnsuccessfulAsync(cancellationToken).ConfigureAwait(false);
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             using var reader = new StreamReader(stream);
             ChatResponse chatResponse = null;
@@ -81,6 +81,7 @@ namespace OpenAI.Chat
                 resultHandler?.Invoke(partialResponse);
             }
 
+            // Should we change this?
             response.EnsureSuccessStatusCode();
 
             if (chatResponse == null) { return null; }
@@ -105,7 +106,7 @@ namespace OpenAI.Chat
             using var request = new HttpRequestMessage(HttpMethod.Post, GetUrl("/completions"));
             request.Content = jsonContent;
             var response = await client.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-            await response.CheckResponseAsync(cancellationToken).ConfigureAwait(false);
+            await response.ThrowApiExceptionIfUnsuccessfulAsync(cancellationToken).ConfigureAwait(false);
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             using var reader = new StreamReader(stream);
             ChatResponse chatResponse = null;
@@ -136,6 +137,7 @@ namespace OpenAI.Chat
                 yield return partialResponse;
             }
 
+            // Should we change this?
             response.EnsureSuccessStatusCode();
 
             if (chatResponse == null) { yield break; }

--- a/OpenAI-DotNet/Common/ApiError.cs
+++ b/OpenAI-DotNet/Common/ApiError.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+using System.Text.Json.Serialization;
+
+namespace OpenAI
+{
+    public class ApiError(string message, string type, string? code, string? param)
+    {
+        [JsonInclude]
+        [JsonPropertyName("message")]
+        public string Message { get; } = message;
+
+        [JsonInclude]
+        [JsonPropertyName("type")]
+        public string Type { get; } = type;
+
+        [JsonInclude]
+        [JsonPropertyName("code")]
+        public string? Code { get; } = code;
+
+        [JsonInclude]
+        [JsonPropertyName("param")]
+        public string? Param { get; } = param;
+    }
+
+    public class ApiErrorResponse
+    {
+        [JsonInclude]
+        [JsonPropertyName("error")]
+        public ApiError? Error { get; init; }
+    }
+}

--- a/OpenAI-DotNet/Common/BaseResponse.cs
+++ b/OpenAI-DotNet/Common/BaseResponse.cs
@@ -34,42 +34,5 @@ namespace OpenAI
         /// </summary>
         [JsonIgnore]
         public string OpenAIVersion { get; internal set; }
-
-        /// <summary>
-        /// The maximum number of requests that are permitted before exhausting the rate limit.
-        /// </summary>
-
-        [JsonIgnore]
-        public int? LimitRequests { get; internal set; }
-
-        /// <summary>
-        /// The maximum number of tokens that are permitted before exhausting the rate limit.
-        /// </summary>
-        [JsonIgnore]
-        public int? LimitTokens { get; internal set; }
-
-        /// <summary>
-        /// The remaining number of requests that are permitted before exhausting the rate limit.
-        /// </summary>
-        [JsonIgnore]
-        public int? RemainingRequests { get; internal set; }
-
-        /// <summary>
-        /// The remaining number of tokens that are permitted before exhausting the rate limit.
-        /// </summary>
-        [JsonIgnore]
-        public int? RemainingTokens { get; internal set; }
-
-        /// <summary>
-        /// The time until the rate limit (based on requests) resets to its initial state.
-        /// </summary>
-        [JsonIgnore]
-        public string ResetRequests { get; internal set; }
-
-        /// <summary>
-        /// The time until the rate limit (based on tokens) resets to its initial state.
-        /// </summary>
-        [JsonIgnore]
-        public string ResetTokens { get; internal set; }
     }
 }

--- a/OpenAI-DotNet/Common/RunError.cs
+++ b/OpenAI-DotNet/Common/RunError.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace OpenAI
 {
-    public sealed class Error
+    public sealed class RunError
     {
         /// <summary>
         /// One of server_error or rate_limit_exceeded.

--- a/OpenAI-DotNet/Completions/CompletionsEndpoint.cs
+++ b/OpenAI-DotNet/Completions/CompletionsEndpoint.cs
@@ -206,7 +206,7 @@ namespace OpenAI.Completions
             using var request = new HttpRequestMessage(HttpMethod.Post, GetUrl());
             request.Content = jsonContent;
             var response = await client.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-            await response.CheckResponseAsync(cancellationToken).ConfigureAwait(false);
+            await response.ThrowApiExceptionIfUnsuccessfulAsync(cancellationToken).ConfigureAwait(false);
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             using var reader = new StreamReader(stream);
 
@@ -315,7 +315,7 @@ namespace OpenAI.Completions
             using var request = new HttpRequestMessage(HttpMethod.Post, GetUrl());
             request.Content = jsonContent;
             var response = await client.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-            await response.CheckResponseAsync(cancellationToken).ConfigureAwait(false);
+            await response.ThrowApiExceptionIfUnsuccessfulAsync(cancellationToken).ConfigureAwait(false);
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             using var reader = new StreamReader(stream);
 

--- a/OpenAI-DotNet/Exceptions/Generated.cs
+++ b/OpenAI-DotNet/Exceptions/Generated.cs
@@ -1,0 +1,170 @@
+﻿#nullable enable
+using OpenAI;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Headers;
+
+public class OpenAiException : Exception
+{
+    public ApiError? Error { get; }
+
+    /// <summary>
+    /// The underlying HTTP response's body in string format.
+    /// </summary>
+    /// <remarks>
+    /// <b>null</b> if the request failed before receiving a response, represented by a <see cref="OpenAIConnectionException"/>.
+    /// </remarks>
+    public string? ResponseBody { get; }
+
+    internal OpenAiException(string? body, string message, ApiError? error = null, Exception? cause = null) : base(message, cause)
+    {
+        ResponseBody = body;
+        Error = error;
+    }
+}
+
+// The following classes extend APIException and are specialized based on different HTTP status codes or error scenarios
+public class OpenAIResponseValidationException : OpenAiException
+{
+    public HttpStatusCode StatusCode { get; set; }
+
+    public OpenAIResponseValidationException(HttpStatusCode statusCode,
+        string body, string message = "Data returned by API invalid for expected schema.", ApiError? error = null) : base(body, message, error)
+    {
+        StatusCode = statusCode;
+    }
+}
+
+public class OpenAIStatusException : OpenAiException
+{
+    public int StatusCode { get; set; }
+
+    public OpenAIStatusException(string message, int statusCode, string body, ApiError? error) : base(body, message, error)
+    {
+        StatusCode = statusCode;
+    }
+}
+
+public class OpenAIConnectionException : OpenAiException
+{
+    public OpenAIConnectionException(Exception cause, string errorMessage = "Connection error.") : base(null, errorMessage, cause: cause) { }
+}
+
+public class OpenAITimeoutException : OpenAIConnectionException
+{
+    public OpenAITimeoutException(Exception cause) : base(cause, "Request timed out.") { }
+}
+
+// Specific HTTP status code exceptions
+public class OpenAIBadRequestException : OpenAIStatusException
+{
+    public OpenAIBadRequestException(string body, ApiError? apiError, string errorMessage = "Bad Request") : base(errorMessage, 400, body, apiError) { }
+}
+
+public class OpenAIAuthenticationException : OpenAIStatusException
+{
+    public OpenAIAuthenticationException(string body, ApiError? apiError, string errorMessage = "Authentication Failed") : base(errorMessage, 401, body, apiError) { }
+}
+
+public class OpenAIPermissionDeniedException : OpenAIStatusException
+{
+    public OpenAIPermissionDeniedException(string body, ApiError? apiError, string errorMessage = "Permission Denied") : base(errorMessage, 403, body, apiError) { }
+}
+
+public class OpenAINotFoundException : OpenAIStatusException
+{
+    public OpenAINotFoundException(string body, ApiError? apiError, string errorMessage = "Not Found") : base(errorMessage, 404, body, apiError) { }
+}
+
+public class ConflictException : OpenAIStatusException
+{
+    public ConflictException(string body, ApiError? apiError, string errorMessage = "Conflict") : base(errorMessage, 409, body, apiError) { }
+}
+
+public class UnprocessableEntityException : OpenAIStatusException
+{
+    public UnprocessableEntityException(string body, ApiError? apiError, string errorMessage = "Unprocessable Entity") : base(errorMessage, 422, body, apiError) { }
+}
+
+public class RateLimitException : OpenAIStatusException
+{
+    private const string XRateLimitLimitRequests = "x-ratelimit-limit-requests";
+    private const string XRateLimitLimitTokens = "x-ratelimit-limit-tokens";
+    private const string XRateLimitRemainingRequests = "x-ratelimit-remaining-requests";
+    private const string XRateLimitRemainingTokens = "x-ratelimit-remaining-tokens";
+    private const string XRateLimitResetRequests = "x-ratelimit-reset-requests";
+    private const string XRateLimitResetTokens = "x-ratelimit-reset-tokens";
+
+    /// <summary>
+    /// The maximum number of requests that are permitted before exhausting the rate limit.
+    /// </summary>
+    public int? LimitRequests { get; }
+
+    /// <summary>
+    /// The maximum number of tokens that are permitted before exhausting the rate limit.
+    /// </summary>
+    public int? LimitTokens { get; }
+
+    /// <summary>
+    /// The remaining number of requests that are permitted before exhausting the rate limit.
+    /// </summary>
+    public int? RemainingRequests { get; }
+
+    /// <summary>
+    /// The remaining number of tokens that are permitted before exhausting the rate limit.
+    /// </summary>
+    public int? RemainingTokens { get; }
+
+    /// <summary>
+    /// The time until the rate limit (based on requests) resets to its initial state.
+    /// </summary>
+    public string? ResetRequests { get; }
+
+    /// <summary>
+    /// The time until the rate limit (based on tokens) resets to its initial state.
+    /// </summary>
+    public string? ResetTokens { get; }
+
+    public RateLimitException(HttpResponseHeaders headers, string body, ApiError? apiError, string errorMessage = "Rate Limit Exceeded") : base(errorMessage, 429, body, apiError)
+    {
+        if (headers.TryGetValues(XRateLimitLimitRequests, out var limitRequests) &&
+                int.TryParse(limitRequests.FirstOrDefault(), out var limitRequestsValue))
+        {
+            LimitRequests = limitRequestsValue;
+        }
+
+        if (headers.TryGetValues(XRateLimitLimitTokens, out var limitTokens) &&
+            int.TryParse(limitTokens.FirstOrDefault(), out var limitTokensValue))
+        {
+            LimitTokens = limitTokensValue;
+        }
+
+        if (headers.TryGetValues(XRateLimitRemainingRequests, out var remainingRequests) &&
+            int.TryParse(remainingRequests.FirstOrDefault(), out var remainingRequestsValue))
+        {
+            RemainingRequests = remainingRequestsValue;
+        }
+
+        if (headers.TryGetValues(XRateLimitRemainingTokens, out var remainingTokens) &&
+            int.TryParse(remainingTokens.FirstOrDefault(), out var remainingTokensValue))
+        {
+            RemainingTokens = remainingTokensValue;
+        }
+
+        if (headers.TryGetValues(XRateLimitResetRequests, out var resetRequests))
+        {
+            ResetRequests = resetRequests.FirstOrDefault();
+        }
+
+        if (headers.TryGetValues(XRateLimitResetTokens, out var resetTokens))
+        {
+            ResetTokens = resetTokens.FirstOrDefault();
+        }
+    }
+}
+
+public class InternalServerException : OpenAIStatusException
+{
+    public InternalServerException(int statusCode, string body, ApiError? apiError) : base("Internal Server Error", statusCode, body, apiError) { }
+}

--- a/OpenAI-DotNet/Extensions/HttpClientExtensions.cs
+++ b/OpenAI-DotNet/Extensions/HttpClientExtensions.cs
@@ -1,0 +1,48 @@
+﻿#nullable enable
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenAI.Extensions
+{
+    internal static class HttpClientExtensions
+    {
+        internal static Task<HttpResponseMessage> GetResponseAsync(
+            this HttpClient client,
+            string url,
+            HttpMethod httpMethod,
+            HttpContent? httpContent = null,
+            CancellationToken cancellationToken = default)
+        {
+            using HttpRequestMessage request = new(httpMethod, url)
+            {
+                Content = httpContent
+            };
+
+            return client.GetResponseAsync(request, cancellationToken: cancellationToken);
+        }
+
+        internal static async Task<HttpResponseMessage> GetResponseAsync(
+            this HttpClient client,
+            HttpRequestMessage request,
+            HttpCompletionOption completionOptions = HttpCompletionOption.ResponseContentRead,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                HttpResponseMessage response = await client.SendAsync(request, completionOptions, cancellationToken).ConfigureAwait(false);
+                await response.ThrowApiExceptionIfUnsuccessfulAsync(cancellationToken).ConfigureAwait(false);
+                return response;
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new OpenAITimeoutException(ex);
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new OpenAITimeoutException(ex);
+            }
+        }
+    }
+}

--- a/OpenAI-DotNet/Extensions/StringExtensions.cs
+++ b/OpenAI-DotNet/Extensions/StringExtensions.cs
@@ -17,6 +17,8 @@ namespace OpenAI.Extensions
         public static bool TryGetEventStreamData(this string streamData, out string eventData)
         {
             const string dataTag = "data: ";
+            const string doneTag = "[DONE]";
+
             eventData = string.Empty;
 
             if (streamData.StartsWith(dataTag))
@@ -24,7 +26,6 @@ namespace OpenAI.Extensions
                 eventData = streamData[dataTag.Length..].Trim();
             }
 
-            const string doneTag = "[DONE]";
             return eventData != doneTag;
         }
 

--- a/OpenAI-DotNet/Files/FilesEndpoint.cs
+++ b/OpenAI-DotNet/Files/FilesEndpoint.cs
@@ -118,7 +118,7 @@ namespace OpenAI.Files
                     }
                 }
 
-                await response.CheckResponseAsync(cancellationToken);
+                await response.ThrowApiExceptionIfUnsuccessfulAsync(cancellationToken);
                 return JsonSerializer.Deserialize<DeletedResponse>(responseAsString, OpenAIClient.JsonSerializationOptions)?.Deleted ?? false;
             }
         }

--- a/OpenAI-DotNet/Threads/RunResponse.cs
+++ b/OpenAI-DotNet/Threads/RunResponse.cs
@@ -62,7 +62,7 @@ namespace OpenAI.Threads
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("last_error")]
-        public Error LastError { get; private set; }
+        public RunError LastError { get; private set; }
 
         /// <summary>
         /// The Unix timestamp (in seconds) for when the thread was created.

--- a/OpenAI-DotNet/Threads/RunStepResponse.cs
+++ b/OpenAI-DotNet/Threads/RunStepResponse.cs
@@ -71,7 +71,7 @@ namespace OpenAI.Threads
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("last_error")]
-        public Error LastError { get; private set; }
+        public RunError LastError { get; private set; }
 
         /// <summary>
         /// The Unix timestamp (in seconds) for when the run step was created.


### PR DESCRIPTION
This design is heavily inspired by the original [python library](https://github.com/openai/openai-python).

I've done my best to make it as close to 1 to 1 as possible. I've not troubled myself with handling retries, which the original library does. I've also not handled what they've done by setting a default timeout of 10 minutes on requests without user-defined cancellation. That I believe is outside the scope of this feature.

Please bear in mind that this is not the final version. For starters, I need to separate my classes outside a sillily named `Generated.cs`, as well as call the new `HttpClient` extension methods where appropriate.

I quickly wanted to put what I've built up till now with the community before diving deeper, hence why this is a draft and why it's committed in a rather "poor" shape. My goal here is rather to show you the changes I've made, and discuss if they're okay, or if I've taken a very wrong route.

Tagging @StephenHodgson for attention.

Related to #193.