### PR TITLE
Add new OpenAI embedding models + dimensions parameter

### DIFF
--- a/OpenAI-DotNet-Tests/TestFixture_06_Embeddings.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_06_Embeddings.cs
@@ -16,7 +16,7 @@ namespace OpenAI.Tests
         }
         
         [Test]
-        public async Task Test_1_CreateEmbeddingWithDimensions()
+        public async Task Test_2_CreateEmbeddingWithDimensions()
         {
             Assert.IsNotNull(OpenAIClient.EmbeddingsEndpoint);
             var embedding = await OpenAIClient.EmbeddingsEndpoint.CreateEmbeddingAsync("The food was delicious and the waiter...",
@@ -27,7 +27,7 @@ namespace OpenAI.Tests
         }
 
         [Test]
-        public async Task Test_2_CreateEmbeddingsWithMultipleInputs()
+        public async Task Test_3_CreateEmbeddingsWithMultipleInputs()
         {
             Assert.IsNotNull(OpenAIClient.EmbeddingsEndpoint);
             var embeddings = new[]

--- a/OpenAI-DotNet-Tests/TestFixture_06_Embeddings.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_06_Embeddings.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System.Threading.Tasks;
+using OpenAI.Models;
 
 namespace OpenAI.Tests
 {
@@ -12,6 +13,17 @@ namespace OpenAI.Tests
             var embedding = await OpenAIClient.EmbeddingsEndpoint.CreateEmbeddingAsync("The food was delicious and the waiter...");
             Assert.IsNotNull(embedding);
             Assert.IsNotEmpty(embedding.Data);
+        }
+        
+        [Test]
+        public async Task Test_1_CreateEmbeddingWithDimensions()
+        {
+            Assert.IsNotNull(OpenAIClient.EmbeddingsEndpoint);
+            var embedding = await OpenAIClient.EmbeddingsEndpoint.CreateEmbeddingAsync("The food was delicious and the waiter...",
+                Model.Embedding_3_Small, dimensions: 512);
+            Assert.IsNotNull(embedding);
+            Assert.IsNotEmpty(embedding.Data);
+            Assert.AreEqual(512, embedding.Data[0].Embedding.Count);
         }
 
         [Test]

--- a/OpenAI-DotNet/Embeddings/EmbeddingsEndpoint.cs
+++ b/OpenAI-DotNet/Embeddings/EmbeddingsEndpoint.cs
@@ -35,9 +35,13 @@ namespace OpenAI.Embeddings
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
+        /// <param name="dimensions">
+        /// The number of dimensions the resulting output embeddings should have.
+        /// Only supported in text-embedding-3 and later models
+        /// </param>
         /// <returns><see cref="EmbeddingsResponse"/></returns>
-        public async Task<EmbeddingsResponse> CreateEmbeddingAsync(string input, string model = null, string user = null)
-            => await CreateEmbeddingAsync(new EmbeddingsRequest(input, model, user)).ConfigureAwait(false);
+        public async Task<EmbeddingsResponse> CreateEmbeddingAsync(string input, string model = null, string user = null, int? dimensions = null)
+            => await CreateEmbeddingAsync(new EmbeddingsRequest(input, model, user, dimensions)).ConfigureAwait(false);
 
         /// <summary>
         /// Creates an embedding vector representing the input text.
@@ -54,11 +58,15 @@ namespace OpenAI.Embeddings
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
+        /// <param name="dimensions">
+        /// The number of dimensions the resulting output embeddings should have.
+        /// Only supported in text-embedding-3 and later models
+        /// </param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="EmbeddingsResponse"/></returns>
-        public async Task<EmbeddingsResponse> CreateEmbeddingAsync(IEnumerable<string> input, string model = null, string user = null, CancellationToken cancellationToken = default)
-            => await CreateEmbeddingAsync(new EmbeddingsRequest(input, model, user), cancellationToken).ConfigureAwait(false);
-
+        public async Task<EmbeddingsResponse> CreateEmbeddingAsync(IEnumerable<string> input, string model = null, string user = null, int? dimensions = null, CancellationToken cancellationToken = default)
+            => await CreateEmbeddingAsync(new EmbeddingsRequest(input, model, user, dimensions), cancellationToken).ConfigureAwait(false);
+        
         /// <summary>
         /// Creates an embedding vector representing the input text.
         /// </summary>

--- a/OpenAI-DotNet/Embeddings/EmbeddingsEndpoint.cs
+++ b/OpenAI-DotNet/Embeddings/EmbeddingsEndpoint.cs
@@ -66,7 +66,7 @@ namespace OpenAI.Embeddings
         /// <returns><see cref="EmbeddingsResponse"/></returns>
         public async Task<EmbeddingsResponse> CreateEmbeddingAsync(IEnumerable<string> input, string model = null, string user = null, int? dimensions = null, CancellationToken cancellationToken = default)
             => await CreateEmbeddingAsync(new EmbeddingsRequest(input, model, user, dimensions), cancellationToken).ConfigureAwait(false);
-        
+
         /// <summary>
         /// Creates an embedding vector representing the input text.
         /// </summary>

--- a/OpenAI-DotNet/Embeddings/EmbeddingsRequest.cs
+++ b/OpenAI-DotNet/Embeddings/EmbeddingsRequest.cs
@@ -25,8 +25,12 @@ namespace OpenAI.Embeddings
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public EmbeddingsRequest(string input, string model = null, string user = null)
-            : this(new List<string> { input }, model, user)
+        /// <param name="dimensions">
+        /// The number of dimensions the resulting output embeddings should have.
+        /// Only supported in text-embedding-3 and later models
+        /// </param>
+        public EmbeddingsRequest(string input, string model = null, string user = null, int? dimensions = null)
+            : this(new List<string> { input }, model, user, dimensions)
         {
             if (string.IsNullOrWhiteSpace(input))
             {
@@ -49,7 +53,12 @@ namespace OpenAI.Embeddings
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public EmbeddingsRequest(IEnumerable<string> input, string model = null, string user = null)
+        /// <param name="dimensions">
+        /// The number of dimensions the resulting output embeddings should have.
+        /// Only supported in text-embedding-3 and later models
+        /// </param>
+        public EmbeddingsRequest(IEnumerable<string> input, string model = null, string user = null,
+            int? dimensions = null)
         {
             Input = input?.ToList();
 
@@ -60,6 +69,7 @@ namespace OpenAI.Embeddings
 
             Model = string.IsNullOrWhiteSpace(model) ? Models.Model.Embedding_Ada_002 : model;
             User = user;
+            Dimensions = dimensions;
         }
 
         [JsonPropertyName("input")]
@@ -67,6 +77,9 @@ namespace OpenAI.Embeddings
 
         [JsonPropertyName("model")]
         public string Model { get; }
+        
+        [JsonPropertyName("dimensions")]
+        public int? Dimensions { get; }
 
         [JsonPropertyName("user")]
         public string User { get; }

--- a/OpenAI-DotNet/Models/Model.cs
+++ b/OpenAI-DotNet/Models/Model.cs
@@ -130,6 +130,10 @@ namespace OpenAI.Models
         /// The default model for <see cref="Embeddings.EmbeddingsEndpoint"/>.
         /// </summary>
         public static Model Embedding_Ada_002 { get; } = new("text-embedding-ada-002", "openai");
+        
+        public static Model Embedding_3_Small { get; } = new("text-embedding-3-small", "openai");
+        
+        public static Model Embedding_3_Large { get; } = new("text-embedding-3-large", "openai");
 
         /// <summary>
         /// The default model for <see cref="Audio.AudioEndpoint"/>.

--- a/OpenAI-DotNet/Models/Model.cs
+++ b/OpenAI-DotNet/Models/Model.cs
@@ -131,8 +131,14 @@ namespace OpenAI.Models
         /// </summary>
         public static Model Embedding_Ada_002 { get; } = new("text-embedding-ada-002", "openai");
         
+        /// <summary>
+        /// A highly efficient model which provides a significant upgrade over its predecessor, the text-embedding-ada-002 model.
+        /// </summary>
         public static Model Embedding_3_Small { get; } = new("text-embedding-3-small", "openai");
         
+        /// <summary>
+        /// A next generation larger model with embeddings of up to 3072 dimensions.
+        /// </summary>
         public static Model Embedding_3_Large { get; } = new("text-embedding-3-large", "openai");
 
         /// <summary>


### PR DESCRIPTION
This PR adds the new OpenAI embedding models, as announced here:

https://openai.com/blog/new-embedding-models-and-api-updates

Also added the new `dimensions` parameter described in the announcement.

- https://github.com/openai/openai-openapi/pull/179