### PR TITLE
OpenAI-DotNet 7.6.5

### DIFF
--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -28,8 +28,10 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <IncludeSymbols>True</IncludeSymbols>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <Version>7.6.4</Version>
+    <Version>7.6.5</Version>
     <PackageReleaseNotes>
+Version 7.6.5
+- Updated api key prefix checks to only be enforced for OpenAI domain
 Version 7.6.4
 - Removed obsolete completions and edit endpoints
 Version 7.6.3

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -214,7 +214,7 @@ namespace OpenAI
             client.DefaultRequestHeaders.Add("User-Agent", "OpenAI-DotNet");
             client.DefaultRequestHeaders.Add("OpenAI-Beta", "assistants=v1");
 
-            if (!OpenAIClientSettings.BaseRequestUrlFormat.Contains(OpenAIClientSettings.AzureOpenAIDomain) &&
+            if (OpenAIClientSettings.BaseRequestUrlFormat.Contains(OpenAIClientSettings.OpenAIDomain) &&
                 (string.IsNullOrWhiteSpace(OpenAIAuthentication.ApiKey) ||
                  (!OpenAIAuthentication.ApiKey.Contains(AuthInfo.SecretKeyPrefix) &&
                   !OpenAIAuthentication.ApiKey.Contains(AuthInfo.SessionKeyPrefix))))


### PR DESCRIPTION
- Updated api key prefix checks to only be enforced for OpenAI domain