### PR TITLE
OpenAI-DotNet 7.7.5

### DIFF
--- a/OpenAI-DotNet/Common/FunctionParameterAttribute.cs
+++ b/OpenAI-DotNet/Common/FunctionParameterAttribute.cs
@@ -7,6 +7,10 @@ namespace OpenAI
     [AttributeUsage(AttributeTargets.Parameter)]
     public sealed class FunctionParameterAttribute : Attribute
     {
+        /// <summary>
+        /// Function parameter attribute to help describe the parameter for the function.
+        /// </summary>
+        /// <param name="description">The description of the parameter and its usage.</param>
         public FunctionParameterAttribute(string description)
         {
             Description = description;

--- a/OpenAI-DotNet/Common/FunctionPropertyAttribute.cs
+++ b/OpenAI-DotNet/Common/FunctionPropertyAttribute.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace OpenAI
 {
-    [AttributeUsage(AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
     public sealed class FunctionPropertyAttribute : Attribute
     {
         /// <summary>

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -28,8 +28,13 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <IncludeSymbols>True</IncludeSymbols>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <Version>7.7.4</Version>
+    <Version>7.7.5</Version>
     <PackageReleaseNotes>
+Version 7.7.5
+- Allow FunctionPropertyAttribute to be assignable to fields
+- Updated Function schema generation
+  - Fall back to complex types, and use $ref for discovered types
+  - Fixed schema generation to properly assign unsigned integer types
 Version 7.7.4
 - Fixed Threads.RunResponse.WaitForStatusChangeAsync timeout
 Version 7.7.3

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -112,7 +112,8 @@ namespace OpenAI
         internal static JsonSerializerOptions JsonSerializationOptions { get; } = new()
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            Converters = { new JsonStringEnumConverterFactory() }
+            Converters = { new JsonStringEnumConverterFactory() },
+            ReferenceHandler = ReferenceHandler.IgnoreCycles,
         };
 
         /// <summary>


### PR DESCRIPTION
- Allow FunctionPropertyAttribute to be assignable to fields
- Updated Function schema generation
  - Fall back to complex types, and use $ref for discovered types
  - Fixed schema generation to properly assign unsigned integer types