### PR TITLE
OpenAI-DotNet 7.7.8

### DIFF
--- a/OpenAI-DotNet-Proxy/OpenAI-DotNet-Proxy.csproj
+++ b/OpenAI-DotNet-Proxy/OpenAI-DotNet-Proxy.csproj
@@ -14,11 +14,14 @@
         <PackageTags>OpenAI, AI, ML, API, gpt, gpt-4, gpt-3.5-turbo, gpt-3, chatGPT, api-proxy, proxy, gateway</PackageTags>
         <Title>OpenAI API Proxy</Title>
         <PackageId>OpenAI-DotNet-Proxy</PackageId>
-        <Version>7.7.7</Version>
+        <Version>7.7.8</Version>
         <Company>RageAgainstThePixel</Company>
         <RootNamespace>OpenAI.Proxy</RootNamespace>
         <PackageIcon>OpenAI-DotNet-Icon.png</PackageIcon>
-        <PackageReleaseNotes>Version 7.7.7
+        <PackageReleaseNotes>Version 7.7.8
+- Added OpenAIProxyStartup.CreateWebApplication to create modern WebApplication
+- Updated OpenAI-DotNet-Test-Proxy to use WebApplication implementation
+Version 7.7.7
 - Added ValidateAuthenticationAsync
         </PackageReleaseNotes>
         <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/OpenAI-DotNet-Proxy/Proxy/OpenAIProxyStartup.cs
+++ b/OpenAI-DotNet-Proxy/Proxy/OpenAIProxyStartup.cs
@@ -99,6 +99,31 @@ namespace OpenAI.Proxy
                 }).Build();
         }
 
+        /// <summary>
+        /// Creates a new <see cref="WebApplication"/> that acts as a proxy web api for OpenAI.
+        /// </summary>
+        /// <typeparam name="T"><see cref="IAuthenticationFilter"/> type to use to validate your custom issued tokens.</typeparam>
+        /// <param name="args">Startup args.</param>
+        /// <param name="openAIClient"><see cref="OpenAIClient"/> with configured <see cref="OpenAIAuthentication"/> and <see cref="OpenAIClientSettings"/>.</param>
+        public static WebApplication CreateWebApplication<T>(string[] args, OpenAIClient openAIClient) where T : class, IAuthenticationFilter
+        {
+            var builder = WebApplication.CreateBuilder(args);
+            builder.WebHost.ConfigureKestrel(options =>
+            {
+                options.AllowSynchronousIO = false;
+                options.Limits.MinRequestBodyDataRate = null;
+                options.Limits.MinResponseDataRate = null;
+                options.Limits.KeepAliveTimeout = TimeSpan.FromMinutes(10);
+                options.Limits.RequestHeadersTimeout = TimeSpan.FromMinutes(2);
+            });
+            builder.Services.AddSingleton(openAIClient);
+            builder.Services.AddSingleton<IAuthenticationFilter, T>();
+            var app = builder.Build();
+            var startup = new OpenAIProxyStartup();
+            startup.Configure(app, app.Environment);
+            return app;
+        }
+
         private static async Task HealthEndpoint(HttpContext context)
         {
             // Respond with a 200 OK status code and a plain text message
@@ -167,7 +192,7 @@ namespace OpenAI.Proxy
             catch (Exception e)
             {
                 httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
-                await httpContext.Response.WriteAsync(e.Message);
+                await httpContext.Response.WriteAsync(e.ToString());
             }
         }
 

--- a/OpenAI-DotNet-Proxy/Proxy/OpenAIProxyStartup.cs
+++ b/OpenAI-DotNet-Proxy/Proxy/OpenAIProxyStartup.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Authentication;
+using System.Text.Json;
 using System.Threading.Tasks;
 using MediaTypeHeaderValue = System.Net.Http.Headers.MediaTypeHeaderValue;
 
@@ -192,7 +193,7 @@ namespace OpenAI.Proxy
             catch (Exception e)
             {
                 httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
-                await httpContext.Response.WriteAsync(e.ToString());
+                await httpContext.Response.WriteAsync(JsonSerializer.Serialize(new { error = new { e.Message, e.StackTrace } }));
             }
         }
 

--- a/OpenAI-DotNet-Proxy/Readme.md
+++ b/OpenAI-DotNet-Proxy/Readme.md
@@ -63,7 +63,19 @@ public partial class Program
         {
             // You will need to implement your own class to properly test
             // custom issued tokens you've setup for your end users.
-            if (!request.Authorization.ToString().Contains(userToken))
+            if (!request.Authorization.ToString().Contains(TestUserToken))
+            {
+                throw new AuthenticationException("User is not authorized");
+            }
+        }
+
+        public override async Task ValidateAuthenticationAsync(IHeaderDictionary request)
+        {
+            await Task.CompletedTask; // remote resource call
+
+            // You will need to implement your own class to properly test
+            // custom issued tokens you've setup for your end users.
+            if (!request.Authorization.ToString().Contains(TestUserToken))
             {
                 throw new AuthenticationException("User is not authorized");
             }

--- a/OpenAI-DotNet-Proxy/Readme.md
+++ b/OpenAI-DotNet-Proxy/Readme.md
@@ -51,7 +51,7 @@ In this example, we demonstrate how to set up and use `OpenAIProxyStartup` in a 
     - Powershell install: `Install-Package OpenAI-DotNet-Proxy`
     - Manually editing .csproj: `<PackageReference Include="OpenAI-DotNet-Proxy" />`
 3. Create a new class that inherits from `AbstractAuthenticationFilter` and override the `ValidateAuthentication` method. This will implement the `IAuthenticationFilter` that you will use to check user session token against your internal server.
-4. In `Program.cs`, create a new proxy web application by calling `OpenAIProxyStartup.CreateDefaultHost` method, passing your custom `AuthenticationFilter` as a type argument.
+4. In `Program.cs`, create a new proxy web application by calling `OpenAIProxyStartup.CreateWebApplication` method, passing your custom `AuthenticationFilter` as a type argument.
 5. Create `OpenAIAuthentication` and `OpenAIClientSettings` as you would normally with your API keys, org id, or Azure settings.
 
 ```csharp
@@ -74,9 +74,8 @@ public partial class Program
     {
         var auth = OpenAIAuthentication.LoadFromEnv();
         var settings = new OpenAIClientSettings(/* your custom settings if using Azure OpenAI */);
-        var openAIClient = new OpenAIClient(auth, settings);
-        var proxy = OpenAIProxyStartup.CreateDefaultHost<AuthenticationFilter>(args, openAIClient);
-        proxy.Run();
+        using var openAIClient = new OpenAIClient(auth, settings);
+        OpenAIProxyStartup.CreateWebApplication<AuthenticationFilter>(args, openAIClient).Run();
     }
 }
 ```

--- a/OpenAI-DotNet-Tests-Proxy/Program.cs
+++ b/OpenAI-DotNet-Tests-Proxy/Program.cs
@@ -1,7 +1,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Hosting;
 using OpenAI.Proxy;
 using System.Security.Authentication;
 using System.Threading.Tasks;
@@ -16,7 +15,6 @@ namespace OpenAI.Tests.Proxy
     {
         private const string TestUserToken = "aAbBcCdDeE123456789";
 
-        // ReSharper disable once ClassNeverInstantiated.Local
         private class AuthenticationFilter : AbstractAuthenticationFilter
         {
             public override void ValidateAuthentication(IHeaderDictionary request)
@@ -46,9 +44,8 @@ namespace OpenAI.Tests.Proxy
         {
             var auth = OpenAIAuthentication.LoadFromEnv();
             var settings = new OpenAIClientSettings(/* your custom settings if using Azure OpenAI */);
-            var openAIClient = new OpenAIClient(auth, settings);
-            var proxy = OpenAIProxyStartup.CreateDefaultHost<AuthenticationFilter>(args, openAIClient);
-            proxy.Run();
+            using var openAIClient = new OpenAIClient(auth, settings);
+            OpenAIProxyStartup.CreateWebApplication<AuthenticationFilter>(args, openAIClient).Run();
         }
     }
 }

--- a/OpenAI-DotNet/Authentication/OpenAIClientSettings.cs
+++ b/OpenAI-DotNet/Authentication/OpenAIClientSettings.cs
@@ -10,6 +10,7 @@ namespace OpenAI
     /// </summary>
     public sealed class OpenAIClientSettings
     {
+        internal const string Https = "https://";
         internal const string OpenAIDomain = "api.openai.com";
         internal const string DefaultOpenAIApiVersion = "v1";
         internal const string AzureOpenAIDomain = "openai.azure.com";
@@ -24,7 +25,7 @@ namespace OpenAI
             ApiVersion = "v1";
             DeploymentId = string.Empty;
             BaseRequest = $"/{ApiVersion}/";
-            BaseRequestUrlFormat = $"https://{ResourceName}{BaseRequest}{{0}}";
+            BaseRequestUrlFormat = $"{Https}{ResourceName}{BaseRequest}{{0}}";
             UseOAuthAuthentication = true;
         }
 
@@ -51,11 +52,11 @@ namespace OpenAI
                 apiVersion = DefaultOpenAIApiVersion;
             }
 
-            ResourceName = domain;
+            ResourceName = domain.Contains("http") ? domain : $"{Https}{domain}";
             ApiVersion = apiVersion;
             DeploymentId = string.Empty;
             BaseRequest = $"/{ApiVersion}/";
-            BaseRequestUrlFormat = $"https://{ResourceName}{BaseRequest}{{0}}";
+            BaseRequestUrlFormat = $"{ResourceName}{BaseRequest}{{0}}";
             UseOAuthAuthentication = true;
         }
 
@@ -97,7 +98,7 @@ namespace OpenAI
             DeploymentId = deploymentId;
             ApiVersion = apiVersion;
             BaseRequest = $"/openai/deployments/{DeploymentId}/";
-            BaseRequestUrlFormat = $"https://{ResourceName}.{AzureOpenAIDomain}{BaseRequest}{{0}}";
+            BaseRequestUrlFormat = $"{Https}{ResourceName}.{AzureOpenAIDomain}{BaseRequest}{{0}}";
             defaultQueryParameters.Add("api-version", ApiVersion);
             UseOAuthAuthentication = useActiveDirectoryAuthentication;
         }
@@ -108,13 +109,13 @@ namespace OpenAI
 
         public string DeploymentId { get; }
 
-        internal string BaseRequest { get; }
+        public string BaseRequest { get; }
 
         internal string BaseRequestUrlFormat { get; }
 
         internal bool UseOAuthAuthentication { get; }
 
-        internal bool IsAzureDeployment => BaseRequestUrlFormat.Contains(AzureOpenAIDomain);
+        public bool IsAzureDeployment => BaseRequestUrlFormat.Contains(AzureOpenAIDomain);
 
         private readonly Dictionary<string, string> defaultQueryParameters = new();
 

--- a/OpenAI-DotNet/Common/Function.cs
+++ b/OpenAI-DotNet/Common/Function.cs
@@ -101,7 +101,6 @@ namespace OpenAI
             MethodInfo = method;
             Parameters = method.GenerateJsonSchema();
             Instance = instance;
-
             functionCache[Name] = this;
         }
 

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -28,8 +28,12 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <IncludeSymbols>True</IncludeSymbols>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <Version>7.7.7</Version>
+    <Version>7.7.8</Version>
     <PackageReleaseNotes>
+Version 7.7.8
+- Updated OpenAICLientSettings.ctr to allow for domain http protocol override (i.e. http://localhost:8080 or http://0.0.0.0:8080)
+- Updated OpenAIClientSettings.BaseRequest public for easier access when implementing custom proxies.
+- Updated OpenAIClientSettings.IsAzureDeployment public for easier access when implementing custom proxies.
 Version 7.7.7
 - Updated static models list
   - Added gpt-4-turbo

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -31,7 +31,7 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <Version>7.7.8</Version>
     <PackageReleaseNotes>
 Version 7.7.8
-- Updated OpenAICLientSettings.ctr to allow for domain http protocol override (i.e. http://localhost:8080 or http://0.0.0.0:8080)
+- Updated OpenAIClientSettings.ctr to allow for domain http protocol override (i.e. http://localhost:8080 or http://0.0.0.0:8080)
 - Updated OpenAIClientSettings.BaseRequest public for easier access when implementing custom proxies.
 - Updated OpenAIClientSettings.IsAzureDeployment public for easier access when implementing custom proxies.
 Version 7.7.7

--- a/README.md
+++ b/README.md
@@ -299,7 +299,19 @@ public partial class Program
         {
             // You will need to implement your own class to properly test
             // custom issued tokens you've setup for your end users.
-            if (!request.Authorization.ToString().Contains(userToken))
+            if (!request.Authorization.ToString().Contains(TestUserToken))
+            {
+                throw new AuthenticationException("User is not authorized");
+            }
+        }
+
+        public override async Task ValidateAuthenticationAsync(IHeaderDictionary request)
+        {
+            await Task.CompletedTask; // remote resource call
+
+            // You will need to implement your own class to properly test
+            // custom issued tokens you've setup for your end users.
+            if (!request.Authorization.ToString().Contains(TestUserToken))
             {
                 throw new AuthenticationException("User is not authorized");
             }

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ In this example, we demonstrate how to set up and use `OpenAIProxyStartup` in a 
     - Powershell install: `Install-Package OpenAI-DotNet-Proxy`
     - Manually editing .csproj: `<PackageReference Include="OpenAI-DotNet-Proxy" />`
 3. Create a new class that inherits from `AbstractAuthenticationFilter` and override the `ValidateAuthentication` method. This will implement the `IAuthenticationFilter` that you will use to check user session token against your internal server.
-4. In `Program.cs`, create a new proxy web application by calling `OpenAIProxyStartup.CreateDefaultHost` method, passing your custom `AuthenticationFilter` as a type argument.
+4. In `Program.cs`, create a new proxy web application by calling `OpenAIProxyStartup.CreateWebApplication` method, passing your custom `AuthenticationFilter` as a type argument.
 5. Create `OpenAIAuthentication` and `OpenAIClientSettings` as you would normally with your API keys, org id, or Azure settings.
 
 ```csharp
@@ -311,8 +311,7 @@ public partial class Program
         var auth = OpenAIAuthentication.LoadFromEnv();
         var settings = new OpenAIClientSettings(/* your custom settings if using Azure OpenAI */);
         using var openAIClient = new OpenAIClient(auth, settings);
-        var proxy = OpenAIProxyStartup.CreateDefaultHost<AuthenticationFilter>(args, openAIClient);
-        proxy.Run();
+        OpenAIProxyStartup.CreateWebApplication<AuthenticationFilter>(args, openAIClient).Run();
     }
 }
 ```


### PR DESCRIPTION
- Updated OpenAIClientSettings.ctr to allow for domain http protocol override (i.e. http://localhost:8080 or http://0.0.0.0:8080)
- Updated OpenAIClientSettings.BaseRequest public for easier access when implementing custom proxies.
- Updated OpenAIClientSettings.IsAzureDeployment public for easier access when implementing custom proxies.

## OpenAI-DotNet-Proxy 7.7.8
- Added OpenAIProxyStartup.CreateWebApplication to create modern WebApplication
- Updated OpenAI-DotNet-Test-Proxy to use WebApplication implementation