### PR TITLE
OpenAI-DotNet 8.0.2

### DIFF
--- a/.github/workflows/Publish-Nuget.yml
+++ b/.github/workflows/Publish-Nuget.yml
@@ -37,11 +37,13 @@ concurrency:
 
 env:
   DOTNET_VERSION: ${{ github.event.inputs.dotnet-version || '6.0.x' }}
-  PACKAGE_VERSION: ''
 
 jobs:
   build:
     if: ${{ !github.event_name == 'pull_request' || !github.event.pull_request.draft }}
+    env:
+      PACKAGE_VERSION: ''
+      COVERAGE_FILE_PATH: ''
     runs-on: ubuntu-latest
 
     steps:
@@ -73,11 +75,18 @@ jobs:
         report_individual_runs: true
         compare_to_earlier_commit: false
 
+    - name: Determine Coverage File Path
+      if: ${{ github.ref != 'refs/heads/main' && github.event_name != 'push' && always() }}
+      shell: bash
+      run: |
+        COVERAGE_FILE_PATH=$(find ./test-results -name 'coverage.cobertura.xml' | head -n 1)
+        echo "COVERAGE_FILE_PATH=$COVERAGE_FILE_PATH" >> $GITHUB_ENV
+
     - name: Code Coverage Summary Report
       if: ${{ github.ref != 'refs/heads/main' && github.event_name != 'push' && always() }}
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
-        filename: test-results/**/coverage.cobertura.xml
+        filename: ${{ env.COVERAGE_FILE_PATH }}
         badge: true
         format: 'markdown'
         output: 'both'

--- a/.github/workflows/Publish-Nuget.yml
+++ b/.github/workflows/Publish-Nuget.yml
@@ -131,6 +131,7 @@ jobs:
       with:
         name: OpenAI-DotNet.${{ env.PACKAGE_VERSION }}
         path: |
+          ${{ github.workspace }}/test-results
           ${{ github.workspace }}/OpenAI-DotNet/bin/Release/OpenAI-DotNet.${{ env.PACKAGE_VERSION }}.nupkg
           ${{ github.workspace }}/OpenAI-DotNet/bin/Release/OpenAI-DotNet.${{ env.PACKAGE_VERSION }}.symbols.nupkg
           ${{ github.workspace }}/OpenAI-DotNet/bin/Release/OpenAI-DotNet-Proxy.${{ env.PACKAGE_VERSION }}.nupkg

--- a/OpenAI-DotNet-Tests/TestFixture_00_02_Tools.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_00_02_Tools.cs
@@ -36,7 +36,9 @@ namespace OpenAI.Tests
                 Tool.FromFunc("test_func", Function),
                 Tool.FromFunc<string, string, string>("test_func_with_args", FunctionWithArgs),
                 Tool.FromFunc("test_func_weather", () => WeatherService.GetCurrentWeatherAsync("my location", WeatherService.WeatherUnit.Celsius)),
-                Tool.FromFunc<List<int>, string>("test_func_with_array_args", FunctionWithArrayArgs)
+                Tool.FromFunc<List<int>, string>("test_func_with_array_args", FunctionWithArrayArgs),
+                Tool.FromFunc<string, string>("test_single_return_arg", arg1 => arg1),
+                Tool.FromFunc("test_no_specifiers", (string arg1) => arg1)
             };
 
             var json = JsonSerializer.Serialize(tools, new JsonSerializerOptions(OpenAIClient.JsonSerializationOptions)
@@ -75,6 +77,26 @@ namespace OpenAI.Tests
             var resultWithArrayArgs = toolWithArrayArgs.InvokeFunction<string>();
             Assert.AreEqual("1, 2, 3, 4, 5", resultWithArrayArgs);
             Console.WriteLine(resultWithArrayArgs);
+
+            var singleReturnArg = tools[4];
+            Assert.IsNotNull(singleReturnArg);
+            singleReturnArg.Function.Arguments = new JsonObject
+            {
+                ["arg1"] = "arg1"
+            };
+            var resultSingleReturnArg = singleReturnArg.InvokeFunction<string>();
+            Assert.AreEqual("arg1", resultSingleReturnArg);
+            Console.WriteLine(resultSingleReturnArg);
+
+            var toolNoSpecifiers = tools[5];
+            Assert.IsNotNull(toolNoSpecifiers);
+            toolNoSpecifiers.Function.Arguments = new JsonObject
+            {
+                ["arg1"] = "arg1"
+            };
+            var resultNoSpecifiers = toolNoSpecifiers.InvokeFunction<string>();
+            Assert.AreEqual("arg1", resultNoSpecifiers);
+            Console.WriteLine(resultNoSpecifiers);
         }
 
         private string Function()

--- a/OpenAI-DotNet-Tests/TestFixture_02_Assistants.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_02_Assistants.cs
@@ -13,10 +13,8 @@ namespace OpenAI.Tests
 {
     internal class TestFixture_02_Assistants : AbstractTestFixture
     {
-        private AssistantResponse testAssistant;
-
         [Test]
-        public async Task Test_01_CreateAssistant()
+        public async Task Test_01_Assistants()
         {
             Assert.IsNotNull(OpenAIClient.AssistantsEndpoint);
             const string testFilePath = "assistant_test_1.txt";
@@ -53,13 +51,54 @@ namespace OpenAI.Tests
                     tools: new[] { Tool.FileSearch });
                 var assistant = await OpenAIClient.AssistantsEndpoint.CreateAssistantAsync(request);
                 Assert.IsNotNull(assistant);
-                Assert.AreEqual("test-assistant", assistant.Name);
-                Assert.AreEqual("Used for unit testing.", assistant.Description);
-                Assert.AreEqual("You are test assistant", assistant.Instructions);
-                Assert.AreEqual(Model.GPT4_Turbo.ToString(), assistant.Model);
-                Assert.IsNotEmpty(assistant.Metadata);
-                testAssistant = assistant;
-                Console.WriteLine($"{assistant} -> {assistant.Metadata["test"]}");
+
+                try
+                {
+                    Assert.AreEqual("test-assistant", assistant.Name);
+                    Assert.AreEqual("Used for unit testing.", assistant.Description);
+                    Assert.AreEqual("You are test assistant", assistant.Instructions);
+                    Assert.AreEqual(Model.GPT4_Turbo.ToString(), assistant.Model);
+                    Assert.IsNotEmpty(assistant.Metadata);
+                    Console.WriteLine($"{assistant} -> {assistant.Metadata["test"]}");
+
+                    var modifiedAssistant = await assistant.ModifyAsync(new(
+                        model: Model.GPT4o,
+                        name: "Test modified",
+                        description: "Modified description",
+                        instructions: "You are modified test assistant",
+                        metadata: new Dictionary<string, string>
+                        {
+                            ["int"] = "2",
+                            ["test"] = assistant.Metadata["test"]
+                        }));
+                    Assert.IsNotNull(modifiedAssistant);
+                    Assert.AreEqual("Test modified", modifiedAssistant.Name);
+                    Assert.AreEqual("Modified description", modifiedAssistant.Description);
+                    Assert.AreEqual("You are modified test assistant", modifiedAssistant.Instructions);
+                    Assert.AreEqual(Model.GPT4o.ToString(), modifiedAssistant.Model);
+                    Assert.IsTrue(modifiedAssistant.Metadata.ContainsKey("test"));
+                    Assert.AreEqual("2", modifiedAssistant.Metadata["int"]);
+                    Assert.AreEqual(modifiedAssistant.Metadata["test"], assistant.Metadata["test"]);
+                    Console.WriteLine($"modified assistant -> {modifiedAssistant.Id}");
+
+                    var assistantsList = await OpenAIClient.AssistantsEndpoint.ListAssistantsAsync();
+                    Assert.IsNotNull(assistantsList);
+                    Assert.IsNotEmpty(assistantsList.Items);
+
+                    foreach (var asst in assistantsList.Items)
+                    {
+                        var retrievedAsst = await OpenAIClient.AssistantsEndpoint.RetrieveAssistantAsync(asst);
+                        Assert.IsNotNull(retrievedAsst);
+
+                        var updatedAsst = await retrievedAsst.UpdateAsync();
+                        Assert.IsNotNull(updatedAsst);
+                    }
+                }
+                finally
+                {
+                    var isDeleted = await assistant.DeleteAsync(deleteToolResources: true);
+                    Assert.IsTrue(isDeleted);
+                }
             }
             finally
             {
@@ -69,51 +108,6 @@ namespace OpenAI.Tests
                     Assert.IsTrue(isDeleted);
                 }
             }
-        }
-
-        [Test]
-        public async Task Test_02_ListAssistants()
-        {
-            Assert.IsNotNull(OpenAIClient.AssistantsEndpoint);
-            var assistantsList = await OpenAIClient.AssistantsEndpoint.ListAssistantsAsync();
-            Assert.IsNotNull(assistantsList);
-            Assert.IsNotEmpty(assistantsList.Items);
-
-            foreach (var assistant in assistantsList.Items)
-            {
-                var retrieved = await OpenAIClient.AssistantsEndpoint.RetrieveAssistantAsync(assistant);
-                Assert.IsNotNull(retrieved);
-                Console.WriteLine($"{retrieved} -> {retrieved.CreatedAt}");
-            }
-        }
-
-        [Test]
-        public async Task Test_03_ModifyAssistants()
-        {
-            Assert.IsNotNull(testAssistant);
-            Assert.IsNotNull(OpenAIClient.AssistantsEndpoint);
-            var assistant = await testAssistant.ModifyAsync(new(
-                model: Model.GPT4o,
-                name: "Test modified",
-                description: "Modified description",
-                instructions: "You are modified test assistant"));
-            Assert.IsNotNull(assistant);
-            Assert.AreEqual("Test modified", assistant.Name);
-            Assert.AreEqual("Modified description", assistant.Description);
-            Assert.AreEqual("You are modified test assistant", assistant.Instructions);
-            Assert.AreEqual(Model.GPT4o.ToString(), assistant.Model);
-            Assert.IsTrue(assistant.Metadata.ContainsKey("test"));
-            Console.WriteLine($"modified assistant -> {assistant.Id}");
-        }
-
-        [Test]
-        public async Task Test_05_DeleteAssistant()
-        {
-            Assert.IsNotNull(testAssistant);
-            Assert.IsNotNull(OpenAIClient.AssistantsEndpoint);
-            var result = await testAssistant.DeleteAsync(deleteToolResources: true);
-            Assert.IsTrue(result);
-            Console.WriteLine($"deleted assistant -> {testAssistant.Id}");
         }
     }
 }

--- a/OpenAI-DotNet-Tests/TestFixture_03_Threads.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_03_Threads.cs
@@ -84,7 +84,6 @@ namespace OpenAI.Tests
                 {
                     file = await OpenAIClient.FilesEndpoint.UploadFileAsync(testFilePath, FilePurpose.Assistants);
                     Assert.NotNull(file);
-                    await Task.Delay(1000);
                 }
                 finally
                 {

--- a/OpenAI-DotNet/Assistants/AssistantExtensions.cs
+++ b/OpenAI-DotNet/Assistants/AssistantExtensions.cs
@@ -111,7 +111,7 @@ namespace OpenAI.Assistants
             }
 
             var tool = assistant.Tools.FirstOrDefault(tool => tool.IsFunction && tool.Function.Name == toolCall.FunctionCall.Name) ??
-                throw new InvalidOperationException($"Failed to find a valid tool for [{toolCall.Id}] {toolCall.Type}");
+                throw new InvalidOperationException($"Failed to find a valid tool for [{toolCall.Id}] {toolCall.FunctionCall.Name}");
             tool.Function.Arguments = toolCall.FunctionCall.Arguments;
             return await tool.InvokeFunctionAsync(cancellationToken).ConfigureAwait(false);
         }

--- a/OpenAI-DotNet/Assistants/AssistantExtensions.cs
+++ b/OpenAI-DotNet/Assistants/AssistantExtensions.cs
@@ -23,19 +23,17 @@ namespace OpenAI.Assistants
         public static async Task<AssistantResponse> ModifyAsync(this AssistantResponse assistant, CreateAssistantRequest request, CancellationToken cancellationToken = default)
             => await assistant.Client.AssistantsEndpoint.ModifyAssistantAsync(
                 assistantId: assistant.Id,
-                request: new CreateAssistantRequest(
-                    assistant: assistant,
-                    model: request.Model,
-                    name: request.Name,
-                    description: request.Description,
-                    instructions: request.Instructions,
-                    toolResources: request.ToolResources,
-                    tools: request.Tools,
-                    metadata: request.Metadata,
-                    temperature: request.Temperature,
-                    topP: request.TopP,
-                    responseFormat: request.ResponseFormat),
+                request: request ?? new(assistant),
                 cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        /// <summary>
+        /// Get the latest status of the assistant.
+        /// </summary>
+        /// <param name="assistant"><see cref="AssistantResponse"/>.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+        /// <returns><see cref="AssistantResponse"/>.</returns>
+        public static async Task<AssistantResponse> UpdateAsync(this AssistantResponse assistant, CancellationToken cancellationToken = default)
+            => await assistant.Client.AssistantsEndpoint.RetrieveAssistantAsync(assistant, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Delete the assistant.
@@ -46,6 +44,11 @@ namespace OpenAI.Assistants
         /// <returns>True, if the <see cref="assistant"/> was successfully deleted.</returns>
         public static async Task<bool> DeleteAsync(this AssistantResponse assistant, bool deleteToolResources = false, CancellationToken cancellationToken = default)
         {
+            if (deleteToolResources)
+            {
+                assistant = await assistant.UpdateAsync(cancellationToken).ConfigureAwait(false);
+            }
+
             var deleteTasks = new List<Task<bool>> { assistant.Client.AssistantsEndpoint.DeleteAssistantAsync(assistant.Id, cancellationToken) };
 
             if (deleteToolResources && assistant.ToolResources?.FileSearch?.VectorStoreIds is { Count: > 0 })
@@ -79,15 +82,16 @@ namespace OpenAI.Assistants
         /// <param name="assistant"><see cref="AssistantResponse"/>.</param>
         /// <param name="toolCall"><see cref="ToolCall"/>.</param>
         /// <returns>Tool output result as <see cref="string"/>.</returns>
+        /// <remarks>Only call this directly on your <see cref="ToolCall"/> if you know the method is synchronous.</remarks>
         public static string InvokeToolCall(this AssistantResponse assistant, ToolCall toolCall)
         {
-            if (toolCall.Type != "function")
+            if (!toolCall.IsFunction)
             {
                 throw new InvalidOperationException($"Cannot invoke built in tool {toolCall.Type}");
             }
 
-            var tool = assistant.Tools.FirstOrDefault(tool => tool.Type == "function" && tool.Function.Name == toolCall.FunctionCall.Name) ??
-                throw new InvalidOperationException($"Failed to find a valid tool for [{toolCall.Id}] {toolCall.Type}");
+            var tool = assistant.Tools.FirstOrDefault(tool => tool.IsFunction && tool.Function.Name == toolCall.FunctionCall.Name) ??
+                throw new InvalidOperationException($"Failed to find a valid tool for [{toolCall.Id}] {toolCall.FunctionCall.Name}");
             tool.Function.Arguments = toolCall.FunctionCall.Arguments;
             return tool.InvokeFunction();
         }
@@ -101,12 +105,12 @@ namespace OpenAI.Assistants
         /// <returns>Tool output result as <see cref="string"/>.</returns>
         public static async Task<string> InvokeToolCallAsync(this AssistantResponse assistant, ToolCall toolCall, CancellationToken cancellationToken = default)
         {
-            if (toolCall.Type != "function")
+            if (!toolCall.IsFunction)
             {
                 throw new InvalidOperationException($"Cannot invoke built in tool {toolCall.Type}");
             }
 
-            var tool = assistant.Tools.FirstOrDefault(tool => tool.Type == "function" && tool.Function.Name == toolCall.FunctionCall.Name) ??
+            var tool = assistant.Tools.FirstOrDefault(tool => tool.IsFunction && tool.Function.Name == toolCall.FunctionCall.Name) ??
                 throw new InvalidOperationException($"Failed to find a valid tool for [{toolCall.Id}] {toolCall.Type}");
             tool.Function.Arguments = toolCall.FunctionCall.Arguments;
             return await tool.InvokeFunctionAsync(cancellationToken).ConfigureAwait(false);
@@ -118,6 +122,7 @@ namespace OpenAI.Assistants
         /// <param name="assistant"><see cref="AssistantResponse"/>.</param>
         /// <param name="toolCall"><see cref="ToolCall"/>.</param>
         /// <returns><see cref="ToolOutput"/>.</returns>
+        /// <remarks>Only call this directly on your <see cref="ToolCall"/> if you know the method is synchronous.</remarks>
         public static ToolOutput GetToolOutput(this AssistantResponse assistant, ToolCall toolCall)
             => new(toolCall.Id, assistant.InvokeToolCall(toolCall));
 
@@ -127,6 +132,7 @@ namespace OpenAI.Assistants
         /// <param name="assistant"><see cref="AssistantResponse"/>.</param>
         /// <param name="toolCalls">A collection of <see cref="ToolCall"/>s.</param>
         /// <returns>A collection of <see cref="ToolOutput"/>s.</returns>
+        [Obsolete("Use GetToolOutputsAsync instead.")]
         public static IReadOnlyList<ToolOutput> GetToolOutputs(this AssistantResponse assistant, IEnumerable<ToolCall> toolCalls)
             => toolCalls.Select(assistant.GetToolOutput).ToList();
 

--- a/OpenAI-DotNet/Assistants/CreateAssistantRequest.cs
+++ b/OpenAI-DotNet/Assistants/CreateAssistantRequest.cs
@@ -77,7 +77,7 @@ namespace OpenAI.Assistants
             IReadOnlyDictionary<string, string> metadata = null,
             double? temperature = null,
             double? topP = null,
-            ChatResponseFormat responseFormat = ChatResponseFormat.Auto)
+            ChatResponseFormat? responseFormat = null)
         : this(
             string.IsNullOrWhiteSpace(model) ? assistant.Model : model,
             string.IsNullOrWhiteSpace(name) ? assistant.Name : name,
@@ -86,22 +86,22 @@ namespace OpenAI.Assistants
             tools ?? assistant.Tools,
             toolResources ?? assistant.ToolResources,
             metadata ?? assistant.Metadata,
-            temperature,
-            topP,
-            responseFormat)
+            temperature ?? assistant.Temperature,
+            topP ?? assistant.TopP,
+            responseFormat ?? assistant.ResponseFormat)
         {
         }
 
         [Obsolete("use new .ctr")]
         public CreateAssistantRequest(
             AssistantResponse assistant,
-            string model = null,
-            string name = null,
-            string description = null,
-            string instructions = null,
-            IEnumerable<Tool> tools = null,
-            IEnumerable<string> files = null,
-            IReadOnlyDictionary<string, string> metadata = null)
+            string model,
+            string name,
+            string description,
+            string instructions,
+            IEnumerable<Tool> tools,
+            IEnumerable<string> files,
+            IReadOnlyDictionary<string, string> metadata)
         {
         }
 

--- a/OpenAI-DotNet/Chat/Choice.cs
+++ b/OpenAI-DotNet/Chat/Choice.cs
@@ -32,10 +32,12 @@ namespace OpenAI.Chat
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("finish_reason")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string FinishReason { get; private set; }
 
         [JsonInclude]
         [JsonPropertyName("finish_details")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public FinishDetails FinishDetails { get; private set; }
 
         /// <summary>
@@ -43,6 +45,7 @@ namespace OpenAI.Chat
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("index")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public int? Index { get; private set; }
 
         /// <summary>
@@ -50,6 +53,7 @@ namespace OpenAI.Chat
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("logprobs")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public LogProbs LogProbs { get; private set; }
 
         public override string ToString() => Message?.Content?.ToString() ?? Delta?.Content ?? string.Empty;
@@ -58,7 +62,10 @@ namespace OpenAI.Chat
 
         public void AppendFrom(Choice other)
         {
-            Index = other?.Index ?? 0;
+            if (other.Index.HasValue)
+            {
+                Index = other.Index.Value;
+            }
 
             if (other?.Message != null)
             {

--- a/OpenAI-DotNet/Chat/Choice.cs
+++ b/OpenAI-DotNet/Chat/Choice.cs
@@ -62,17 +62,19 @@ namespace OpenAI.Chat
 
         public void AppendFrom(Choice other)
         {
+            if (other == null) { return; }
+
             if (other.Index.HasValue)
             {
                 Index = other.Index.Value;
             }
 
-            if (other?.Message != null)
+            if (other.Message != null)
             {
                 Message = other.Message;
             }
 
-            if (other?.Delta != null)
+            if (other.Delta != null)
             {
                 if (Message == null)
                 {
@@ -84,17 +86,17 @@ namespace OpenAI.Chat
                 }
             }
 
-            if (other?.LogProbs != null)
+            if (other.LogProbs != null)
             {
                 LogProbs = other.LogProbs;
             }
 
-            if (!string.IsNullOrWhiteSpace(other?.FinishReason))
+            if (!string.IsNullOrWhiteSpace(other.FinishReason))
             {
                 FinishReason = other.FinishReason;
             }
 
-            if (other?.FinishDetails != null)
+            if (other.FinishDetails != null)
             {
                 FinishDetails = other.FinishDetails;
             }

--- a/OpenAI-DotNet/Common/Annotation.cs
+++ b/OpenAI-DotNet/Common/Annotation.cs
@@ -9,6 +9,7 @@ namespace OpenAI
     {
         [JsonInclude]
         [JsonPropertyName("index")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public int? Index { get; private set; }
 
         [JsonInclude]
@@ -30,6 +31,7 @@ namespace OpenAI
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("file_citation")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public FileCitation FileCitation { get; private set; }
 
         /// <summary>
@@ -37,6 +39,7 @@ namespace OpenAI
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("file_path")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public FilePath FilePath { get; private set; }
 
         [JsonInclude]
@@ -50,6 +53,11 @@ namespace OpenAI
         public void AppendFrom(Annotation other)
         {
             if (other == null) { return; }
+
+            if (other.Index.HasValue)
+            {
+                Index = other.Index.Value;
+            }
 
             if (!string.IsNullOrWhiteSpace(other.Text))
             {

--- a/OpenAI-DotNet/Common/CodeInterpreterResources.cs
+++ b/OpenAI-DotNet/Common/CodeInterpreterResources.cs
@@ -10,6 +10,8 @@ namespace OpenAI
     /// </summary>
     public sealed class CodeInterpreterResources
     {
+        public CodeInterpreterResources() { }
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -22,6 +24,12 @@ namespace OpenAI
             FileIds = fileIds;
         }
 
+        /// <inheritdoc />
+        public CodeInterpreterResources(string fileId)
+            : this(new List<string> { fileId })
+        {
+        }
+
         /// <summary>
         /// A list of file IDs made available to the <see cref="Tool.CodeInterpreter"/> tool.
         /// There can be a maximum of 20 files associated with the tool.
@@ -29,6 +37,8 @@ namespace OpenAI
         [JsonInclude]
         [JsonPropertyName("file_ids")]
         public IReadOnlyList<string> FileIds { get; private set; }
+
+        public static implicit operator CodeInterpreterResources(string fileId) => new(fileId);
 
         public static implicit operator CodeInterpreterResources(List<string> fileIds) => new(fileIds);
     }

--- a/OpenAI-DotNet/Common/Content.cs
+++ b/OpenAI-DotNet/Common/Content.cs
@@ -55,7 +55,7 @@ namespace OpenAI
         [JsonInclude]
         [JsonPropertyName("index")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public int? Index { get; }
+        public int? Index { get; private set; }
 
         [JsonInclude]
         [JsonPropertyName("type")]
@@ -101,6 +101,11 @@ namespace OpenAI
             if (other.Type > 0)
             {
                 Type = other.Type;
+            }
+
+            if (other.Index.HasValue)
+            {
+                Index = other.Index.Value;
             }
 
             if (other.Text is TextContent otherTextContent)

--- a/OpenAI-DotNet/Common/FileCitation.cs
+++ b/OpenAI-DotNet/Common/FileCitation.cs
@@ -1,5 +1,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Text.Json.Serialization;
 
 namespace OpenAI
@@ -16,8 +17,10 @@ namespace OpenAI
         /// <summary>
         /// The specific quote in the file.
         /// </summary>
+        [Obsolete("Removed")]
         [JsonInclude]
         [JsonPropertyName("quote")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Quote { get; private set; }
     }
 }

--- a/OpenAI-DotNet/Common/FileSearchOptions.cs
+++ b/OpenAI-DotNet/Common/FileSearchOptions.cs
@@ -1,0 +1,26 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace OpenAI
+{
+    public sealed class FileSearchOptions
+    {
+        public FileSearchOptions() { }
+
+        public FileSearchOptions(int maxNumberOfResults)
+        {
+            MaxNumberOfResults = maxNumberOfResults switch
+            {
+                < 1 => throw new ArgumentOutOfRangeException(nameof(maxNumberOfResults), "Max number of results must be greater than 0."),
+                > 50 => throw new ArgumentOutOfRangeException(nameof(maxNumberOfResults), "Max number of results must be less than 50."),
+                _ => maxNumberOfResults
+            };
+        }
+
+        [JsonInclude]
+        [JsonPropertyName("max_num_results")]
+        public int MaxNumberOfResults { get; private set; }
+    }
+}

--- a/OpenAI-DotNet/Common/Function.cs
+++ b/OpenAI-DotNet/Common/Function.cs
@@ -258,13 +258,18 @@ namespace OpenAI
             {
                 var (function, invokeArgs) = ValidateFunctionArguments();
 
+                if (function.MethodInfo.ReturnType == typeof(Task))
+                {
+                    throw new InvalidOperationException("Cannot invoke an async function synchronously. Use InvokeAsync() instead.");
+                }
+
+                var result = InvokeInternal<object>(function, invokeArgs);
+
                 if (function.MethodInfo.ReturnType == typeof(void))
                 {
-                    function.MethodInfo.Invoke(function.Instance, invokeArgs);
                     return "{\"result\": \"success\"}";
                 }
 
-                var result = Invoke<object>();
                 return JsonSerializer.Serialize(new { result }, OpenAIClient.JsonSerializationOptions);
             }
             catch (Exception e)
@@ -284,8 +289,13 @@ namespace OpenAI
             try
             {
                 var (function, invokeArgs) = ValidateFunctionArguments();
-                var result = function.MethodInfo.Invoke(function.Instance, invokeArgs);
-                return result == null ? default : (T)result;
+
+                if (function.MethodInfo.ReturnType == typeof(Task))
+                {
+                    throw new InvalidOperationException("Cannot invoke an async function synchronously. Use InvokeAsync() instead.");
+                }
+
+                return InvokeInternal<T>(function, invokeArgs);
             }
             catch (Exception e)
             {
@@ -304,19 +314,13 @@ namespace OpenAI
             try
             {
                 var (function, invokeArgs) = ValidateFunctionArguments(cancellationToken);
+                var result = await InvokeInternalAsync<object>(function, invokeArgs);
 
                 if (function.MethodInfo.ReturnType == typeof(Task))
                 {
-                    if (function.MethodInfo.Invoke(function.Instance, invokeArgs) is not Task task)
-                    {
-                        throw new InvalidOperationException($"The function {Name} did not return a valid Task.");
-                    }
-
-                    await task;
                     return "{\"result\": \"success\"}";
                 }
 
-                var result = await InvokeAsync<object>(cancellationToken);
                 return JsonSerializer.Serialize(new { result }, OpenAIClient.JsonSerializationOptions);
             }
             catch (Exception e)
@@ -338,22 +342,40 @@ namespace OpenAI
             {
                 var (function, invokeArgs) = ValidateFunctionArguments(cancellationToken);
 
-                if (function.MethodInfo.Invoke(function.Instance, invokeArgs) is not Task task)
+                if (function.MethodInfo.ReturnType == typeof(Task))
                 {
-                    throw new InvalidOperationException($"The function {Name} did not return a valid Task.");
+                    throw new InvalidOperationException("Cannot invoke an async function synchronously. Use InvokeAsync() instead.");
                 }
 
-                await task;
-                // ReSharper disable once InconsistentNaming
-                const string Result = nameof(Result);
-                var resultProperty = task.GetType().GetProperty(Result);
-                return (T)resultProperty?.GetValue(task);
+                return await InvokeInternalAsync<T>(function, invokeArgs);
             }
             catch (Exception e)
             {
                 Console.WriteLine(e);
                 throw;
             }
+        }
+
+        private static T InvokeInternal<T>(Function function, object[] invokeArgs)
+        {
+            var result = function.MethodInfo.Invoke(function.Instance, invokeArgs);
+            return result == null ? default : (T)result;
+        }
+
+        private static async Task<T> InvokeInternalAsync<T>(Function function, object[] invokeArgs)
+        {
+            var result = InvokeInternal<T>(function, invokeArgs);
+
+            if (result is not Task task)
+            {
+                return result;
+            }
+
+            await task;
+            // ReSharper disable once InconsistentNaming
+            const string Result = nameof(Result);
+            var resultProperty = task.GetType().GetProperty(Result);
+            return (T)resultProperty?.GetValue(task);
         }
 
         private (Function function, object[] invokeArgs) ValidateFunctionArguments(CancellationToken cancellationToken = default)

--- a/OpenAI-DotNet/Common/ImageFile.cs
+++ b/OpenAI-DotNet/Common/ImageFile.cs
@@ -10,6 +10,8 @@ namespace OpenAI
     /// </summary>
     public sealed class ImageFile : IAppendable<ImageFile>
     {
+        public ImageFile() { }
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -30,7 +32,7 @@ namespace OpenAI
         [JsonInclude]
         [JsonPropertyName("index")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public int? Index { get; }
+        public int? Index { get; private set; }
 
         /// <summary>
         /// The file ID of the image in the message content.
@@ -55,6 +57,11 @@ namespace OpenAI
         public void AppendFrom(ImageFile other)
         {
             if (other == null) { return; }
+
+            if (other.Index.HasValue)
+            {
+                Index = other.Index.Value;
+            }
 
             if (!string.IsNullOrWhiteSpace(other.FileId))
             {

--- a/OpenAI-DotNet/Common/ImageUrl.cs
+++ b/OpenAI-DotNet/Common/ImageUrl.cs
@@ -10,6 +10,8 @@ namespace OpenAI
     /// </summary>
     public sealed class ImageUrl : IAppendable<ImageUrl>
     {
+        public ImageUrl() { }
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -53,6 +55,11 @@ namespace OpenAI
         public void AppendFrom(ImageUrl other)
         {
             if (other == null) { return; }
+
+            if (other.Index.HasValue)
+            {
+                Index = other.Index.Value;
+            }
 
             if (!string.IsNullOrWhiteSpace(other.Url))
             {

--- a/OpenAI-DotNet/Common/TextContent.cs
+++ b/OpenAI-DotNet/Common/TextContent.cs
@@ -54,6 +54,11 @@ namespace OpenAI
         {
             if (other == null) { return; }
 
+            if (other.Index.HasValue)
+            {
+                Index = other.Index.Value;
+            }
+
             if (!string.IsNullOrWhiteSpace(other.Value))
             {
                 Value += other.Value;

--- a/OpenAI-DotNet/Common/ToolResources.cs
+++ b/OpenAI-DotNet/Common/ToolResources.cs
@@ -46,5 +46,7 @@ namespace OpenAI
         public static implicit operator ToolResources(FileSearchResources fileSearch) => new(fileSearch);
 
         public static implicit operator ToolResources(CodeInterpreterResources codeInterpreter) => new(codeInterpreter);
+
+        public static implicit operator ToolResources(VectorStoreRequest vectorStoreRequest) => new(new FileSearchResources(vectorStoreRequest));
     }
 }

--- a/OpenAI-DotNet/Common/VectorStoreRequest.cs
+++ b/OpenAI-DotNet/Common/VectorStoreRequest.cs
@@ -11,6 +11,8 @@ namespace OpenAI
     /// </summary>
     public sealed class VectorStoreRequest
     {
+        public VectorStoreRequest() { }
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -27,6 +29,12 @@ namespace OpenAI
         {
             FileIds = fileIds;
             Metadata = metadata;
+        }
+
+        /// <inheritdoc />
+        public VectorStoreRequest(string fileId, IReadOnlyDictionary<string, string> metadata = null)
+            : this(new List<string> { fileId }, metadata)
+        {
         }
 
         /// <summary>
@@ -46,7 +54,7 @@ namespace OpenAI
         [JsonPropertyName("metadata")]
         public IReadOnlyDictionary<string, string> Metadata { get; private set; }
 
-        public static implicit operator VectorStoreRequest(string fileId) => new(new List<string> { fileId });
+        public static implicit operator VectorStoreRequest(string fileId) => new(fileId);
 
         public static implicit operator VectorStoreRequest(List<string> fileIds) => new(fileIds);
     }

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -28,8 +28,18 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <IncludeSymbols>True</IncludeSymbols>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <Version>8.0.1</Version>
+    <Version>8.0.2</Version>
     <PackageReleaseNotes>
+Version 8.0.2
+- Fixed Thread.Message.Attachement serialization
+- Fixed CreateAssistantRequest to properly copy all override assistant properties
+- Fixed some objects that are chunked, were not properly being appended to the final object
+- Added FileSearchOptions to Tool.FileSearch
+- Added some additional constructor overloads for CodeInterpreterResources
+- Added some additional constructor overloads for VectorStoreRequest
+- Thread.DeleteAsync and Assistant.DeleteAsync now fetch the latest before deleting when deleteToolResources is also requested
+- Refactored the way Function handles reflected invocations for both synchronous and asynchronous calls
+  - Function.InvokeAsync will now properly also call synchronous invocations in the tool call collection
 Version 8.0.1
 - Fixed Thread.Run.Status enum ordering
 Version 8.0.0

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -40,6 +40,7 @@ Version 8.0.2
 - Thread.DeleteAsync and Assistant.DeleteAsync now fetch the latest before deleting when deleteToolResources is also requested
 - Refactored the way Function handles reflected invocations for both synchronous and asynchronous calls
   - Function.InvokeAsync will now properly also call synchronous invocations in the tool call collection
+- Refactored Threads/Assistant Unit Tests
 Version 8.0.1
 - Fixed Thread.Run.Status enum ordering
 Version 8.0.0

--- a/OpenAI-DotNet/Threads/CodeInterpreterOutputs.cs
+++ b/OpenAI-DotNet/Threads/CodeInterpreterOutputs.cs
@@ -42,6 +42,11 @@ namespace OpenAI.Threads
                 Type = other.Type;
             }
 
+            if (other.Index.HasValue)
+            {
+                Index = other.Index.Value;
+            }
+
             if (!string.IsNullOrWhiteSpace(other.Logs))
             {
                 Logs += other.Logs;

--- a/OpenAI-DotNet/Threads/CreateThreadRequest.cs
+++ b/OpenAI-DotNet/Threads/CreateThreadRequest.cs
@@ -32,6 +32,7 @@ namespace OpenAI.Threads
             Metadata = metadata;
         }
 
+        /// <inheritdoc />
         public CreateThreadRequest(string message) : this(new[] { new Message(message) })
         {
         }

--- a/OpenAI-DotNet/Threads/MessageResponse.cs
+++ b/OpenAI-DotNet/Threads/MessageResponse.cs
@@ -146,7 +146,7 @@ namespace OpenAI.Threads
         /// A list of files attached to the message, and the tools they were added to.
         /// </summary>
         [JsonInclude]
-        [JsonPropertyName("Attachments")]
+        [JsonPropertyName("attachments")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public IReadOnlyList<Attachment> Attachments { get; private set; }
 

--- a/OpenAI-DotNet/Threads/ThreadExtensions.cs
+++ b/OpenAI-DotNet/Threads/ThreadExtensions.cs
@@ -44,7 +44,7 @@ namespace OpenAI.Threads
         {
             if (deleteToolResources)
             {
-                thread = await thread.UpdateAsync(cancellationToken: cancellationToken);
+                thread = await thread.UpdateAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
             var deleteTasks = new List<Task<bool>> { thread.Client.ThreadsEndpoint.DeleteThreadAsync(thread, cancellationToken) };

--- a/OpenAI-DotNet/Threads/ThreadExtensions.cs
+++ b/OpenAI-DotNet/Threads/ThreadExtensions.cs
@@ -42,6 +42,11 @@ namespace OpenAI.Threads
         /// <returns>True, if the thread was successfully deleted.</returns>
         public static async Task<bool> DeleteAsync(this ThreadResponse thread, bool deleteToolResources = false, CancellationToken cancellationToken = default)
         {
+            if (deleteToolResources)
+            {
+                thread = await thread.UpdateAsync(cancellationToken: cancellationToken);
+            }
+
             var deleteTasks = new List<Task<bool>> { thread.Client.ThreadsEndpoint.DeleteThreadAsync(thread, cancellationToken) };
 
             if (deleteToolResources && thread.ToolResources?.FileSearch?.VectorStoreIds is { Count: > 0 })

--- a/OpenAI-DotNet/Threads/ToolCall.cs
+++ b/OpenAI-DotNet/Threads/ToolCall.cs
@@ -9,10 +9,9 @@ namespace OpenAI.Threads
 {
     public sealed class ToolCall : IAppendable<ToolCall>
     {
-        public ToolCall() { }
-
         [JsonInclude]
         [JsonPropertyName("index")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public int? Index { get; private set; }
 
         /// <summary>
@@ -61,11 +60,19 @@ namespace OpenAI.Threads
         [Obsolete("Removed")]
         public object Retrieval { get; private set; }
 
+        [JsonIgnore]
+        public bool IsFunction => Type == "function";
+
         public void AppendFrom(ToolCall other)
         {
             if (other == null)
             {
                 return;
+            }
+
+            if (other.Index.HasValue)
+            {
+                Index = other.Index;
             }
 
             if (!string.IsNullOrWhiteSpace(other.Id))


### PR DESCRIPTION
- Fixed Thread.Message.Attachement serialization
- Fixed CreateAssistantRequest to properly copy all override assistant properties
- Fixed some objects that are chunked, were not properly being appended to the final object
- Added FileSearchOptions to Tool.FileSearch
- Added some additional constructor overloads for CodeInterpreterResources
- Added some additional constructor overloads for VectorStoreRequest
- Thread.DeleteAsync and Assistant.DeleteAsync now fetch the latest before deleting when deleteToolResources is also requested
- Refactored the way Function handles reflected invocations for both synchronous and asynchronous calls
  - Function.InvokeAsync will now properly also call synchronous invocations in the tool call collection
- Refactored Threads/Assistant Unit Tests