### PR TITLE
OpenAI-DotNet 8.1.0

### DIFF
--- a/OpenAI-DotNet-Tests/TestFixture_03_Threads.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_03_Threads.cs
@@ -502,7 +502,11 @@ namespace OpenAI.Tests
         public async Task Test_04_03_CreateThreadAndRun_Streaming_ToolCalls()
         {
             Assert.NotNull(OpenAIClient.ThreadsEndpoint);
-            var tools = Tool.GetAllAvailableTools();
+
+            var tools = new List<Tool>
+            {
+                Tool.GetOrCreateTool(typeof(DateTimeUtility), nameof(DateTimeUtility.GetDateTime))
+            };
             var assistantRequest = new CreateAssistantRequest(
                 instructions: "You are a helpful assistant.",
                 tools: tools);

--- a/OpenAI-DotNet-Tests/TestFixture_03_Threads.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_03_Threads.cs
@@ -257,7 +257,7 @@ namespace OpenAI.Tests
                 var message = await thread.CreateMessageAsync("I need to solve the equation `3x + 11 = 14`. Can you help me?");
                 Assert.NotNull(message);
 
-                var run = await thread.CreateRunAsync(assistant, streamEvent =>
+                var run = await thread.CreateRunAsync(assistant, async streamEvent =>
                 {
                     Console.WriteLine(streamEvent.ToJsonString());
 
@@ -300,11 +300,9 @@ namespace OpenAI.Tests
                         case Error errorEvent:
                             Assert.NotNull(errorEvent);
                             break;
-                        //default:
-                            // handle event not already processed by library
-                            // var @event = JsonSerializer.Deserialize<T>(streamEvent.ToJsonString());
-                            //break;
                     }
+
+                    await Task.CompletedTask;
                 });
 
                 Assert.IsNotNull(run);
@@ -343,7 +341,7 @@ namespace OpenAI.Tests
 
             try
             {
-                async void StreamEventHandler(IServerSentEvent streamEvent)
+                async Task StreamEventHandler(IServerSentEvent streamEvent)
                 {
                     try
                     {
@@ -469,9 +467,10 @@ namespace OpenAI.Tests
             try
             {
                 var run = await assistant.CreateThreadAndRunAsync("I need to solve the equation `3x + 11 = 14`. Can you help me?",
-                    @event =>
+                    async @event =>
                     {
                         Console.WriteLine(@event.ToJsonString());
+                        await Task.CompletedTask;
                     });
                 Assert.IsNotNull(run);
                 thread = await run.GetThreadAsync();
@@ -500,7 +499,72 @@ namespace OpenAI.Tests
         }
 
         [Test]
-        public async Task Test_04_03_CreateThreadAndRun_SubmitToolOutput()
+        public async Task Test_04_03_CreateThreadAndRun_Streaming_ToolCalls()
+        {
+            Assert.NotNull(OpenAIClient.ThreadsEndpoint);
+            var tools = Tool.GetAllAvailableTools();
+            var assistantRequest = new CreateAssistantRequest(
+                instructions: "You are a helpful assistant.",
+                tools: tools);
+            var assistant = await OpenAIClient.AssistantsEndpoint.CreateAssistantAsync(assistantRequest);
+            Assert.IsNotNull(assistant);
+            ThreadResponse thread = null;
+            // check if any exceptions thrown in stream event handler
+            var exceptionThrown = false;
+
+            try
+            {
+                async Task StreamEventHandler(IServerSentEvent streamEvent)
+                {
+                    Console.WriteLine($"{streamEvent.ToJsonString()}");
+
+                    try
+                    {
+                        switch (streamEvent)
+                        {
+                            case ThreadResponse threadResponse:
+                                thread = threadResponse;
+                                break;
+                            case RunResponse runResponse:
+                                if (runResponse.Status == RunStatus.RequiresAction)
+                                {
+                                    var toolOutputs = await assistant.GetToolOutputsAsync(runResponse);
+                                    var toolRun = await runResponse.SubmitToolOutputsAsync(toolOutputs, StreamEventHandler);
+                                    Assert.NotNull(toolRun);
+                                    Assert.IsTrue(toolRun.Status == RunStatus.Completed);
+                                }
+                                break;
+                            case Error errorResponse:
+                                throw errorResponse.Exception ?? new Exception(errorResponse.Message);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                        exceptionThrown = true;
+                    }
+                }
+
+                var run = await assistant.CreateThreadAndRunAsync("What date is it?", StreamEventHandler);
+                Assert.NotNull(thread);
+                Assert.IsNotNull(run);
+                Assert.IsFalse(exceptionThrown);
+                Assert.IsTrue(run.Status == RunStatus.Completed);
+            }
+            finally
+            {
+                await assistant.DeleteAsync(deleteToolResources: thread == null);
+
+                if (thread != null)
+                {
+                    var isDeleted = await thread.DeleteAsync(deleteToolResources: true);
+                    Assert.IsTrue(isDeleted);
+                }
+            }
+        }
+
+        [Test]
+        public async Task Test_04_04_CreateThreadAndRun_SubmitToolOutput()
         {
             var tools = new List<Tool>
             {

--- a/OpenAI-DotNet-Tests/TestFixture_04_Chat.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_04_Chat.cs
@@ -144,7 +144,10 @@ namespace OpenAI.Tests
                 Console.WriteLine($"{message.Role}: {message.Content}");
             }
 
-            var tools = Tool.GetAllAvailableTools(false, forceUpdate: true, clearCache: true);
+            var tools = new List<Tool>
+            {
+                Tool.GetOrCreateTool(typeof(WeatherService), nameof(WeatherService.GetCurrentWeatherAsync))
+            };
             var chatRequest = new ChatRequest(messages, tools: tools, toolChoice: "none");
             var response = await OpenAIClient.ChatEndpoint.GetCompletionAsync(chatRequest);
             Assert.IsNotNull(response);
@@ -211,7 +214,10 @@ namespace OpenAI.Tests
                 Console.WriteLine($"{message.Role}: {message.Content}");
             }
 
-            var tools = Tool.GetAllAvailableTools(false);
+            var tools = new List<Tool>
+            {
+                Tool.GetOrCreateTool(typeof(WeatherService), nameof(WeatherService.GetCurrentWeatherAsync))
+            };
             var chatRequest = new ChatRequest(messages, tools: tools, toolChoice: "none");
             var response = await OpenAIClient.ChatEndpoint.StreamCompletionAsync(chatRequest, partialResponse =>
             {

--- a/OpenAI-DotNet-Tests/TestServices/WeatherService.cs
+++ b/OpenAI-DotNet-Tests/TestServices/WeatherService.cs
@@ -31,4 +31,11 @@ namespace OpenAI.Tests.Weather
 
         public static int CelsiusToFahrenheit(int celsius) => (celsius * 9 / 5) + 32;
     }
+
+    internal static class DateTimeUtility
+    {
+        [Function("Get the current date and time.")]
+        public static async Task<string> GetDateTime()
+            => await Task.FromResult(DateTimeOffset.Now.ToString());
+    }
 }

--- a/OpenAI-DotNet/Assistants/AssistantExtensions.cs
+++ b/OpenAI-DotNet/Assistants/AssistantExtensions.cs
@@ -63,15 +63,23 @@ namespace OpenAI.Assistants
             return deleteTasks.TrueForAll(task => task.Result);
         }
 
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public static async Task<RunResponse> CreateThreadAndRunAsync(this AssistantResponse assistant, CreateThreadRequest request, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await CreateThreadAndRunAsync(assistant, request, streamEventHandler == null ? null : async serverSentEvent =>
+            {
+                streamEventHandler.Invoke(serverSentEvent);
+                await Task.CompletedTask;
+            }, cancellationToken);
+
         /// <summary>
         /// Create a thread and run it.
         /// </summary>
         /// <param name="assistant"><see cref="AssistantResponse"/>.</param>
         /// <param name="request">Optional, <see cref="CreateThreadRequest"/>.</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public static async Task<RunResponse> CreateThreadAndRunAsync(this AssistantResponse assistant, CreateThreadRequest request = null, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public static async Task<RunResponse> CreateThreadAndRunAsync(this AssistantResponse assistant, CreateThreadRequest request = null, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
             => await assistant.Client.ThreadsEndpoint.CreateThreadAndRunAsync(new CreateThreadAndRunRequest(assistant.Id, createThreadRequest: request), streamEventHandler, cancellationToken).ConfigureAwait(false);
 
         #region Tools

--- a/OpenAI-DotNet/Chat/ChatResponse.cs
+++ b/OpenAI-DotNet/Chat/ChatResponse.cs
@@ -77,7 +77,14 @@ namespace OpenAI.Chat
         {
             if (other is null) { return; }
 
-            if (!string.IsNullOrWhiteSpace(other.Id))
+            if (!string.IsNullOrWhiteSpace(Id))
+            {
+                if (Id != other.Id)
+                {
+                    throw new InvalidOperationException($"Attempting to append a different object than the original! {Id} != {other.Id}");
+                }
+            }
+            else
             {
                 Id = other.Id;
             }

--- a/OpenAI-DotNet/Common/Error.cs
+++ b/OpenAI-DotNet/Common/Error.cs
@@ -1,5 +1,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Text;
 using System.Text.Json.Serialization;
 
@@ -7,6 +8,15 @@ namespace OpenAI
 {
     public sealed class Error : BaseResponse, IServerSentEvent
     {
+        public Error() { }
+
+        internal Error(Exception e)
+        {
+            Type = e.GetType().Name;
+            Message = e.Message;
+            Exception = e;
+        }
+
         /// <summary>
         /// An error code identifying the error type.
         /// </summary>
@@ -49,6 +59,9 @@ namespace OpenAI
 
         [JsonIgnore]
         public string Object => "error";
+
+        [JsonIgnore]
+        public Exception Exception { get; }
 
         public override string ToString()
         {

--- a/OpenAI-DotNet/Common/Function.cs
+++ b/OpenAI-DotNet/Common/Function.cs
@@ -154,6 +154,7 @@ namespace OpenAI
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Description { get; private set; }
 
         private string parametersString;
@@ -166,6 +167,7 @@ namespace OpenAI
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("parameters")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public JsonNode Parameters
         {
             get
@@ -190,6 +192,7 @@ namespace OpenAI
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("arguments")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public JsonNode Arguments
         {
             get

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -28,8 +28,13 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <IncludeSymbols>True</IncludeSymbols>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <Version>8.0.3</Version>
+    <Version>8.1.0</Version>
     <PackageReleaseNotes>
+Version 8.1.0
+- Fixed streaming event race conditions where the subscriber to the stream would finish before steam events were executed
+- Refactored streaming events callbacks from Action&lt;IServerSentEvent&gt; to Func&lt;IServerSentEvent, Task&gt;
+- Added Exception data to OpenAI.Error response
+- Added ChatEndpoint.StreamCompletionAsync with Func&lt;ChatResponse, Task&gt; overload
 Version 8.0.3
 - Fixed Thread.MessageResponse and Thread.RunStepResponse Delta stream event objects not being properly populated
 - Added Thread.MessageDelta.PrintContent()

--- a/OpenAI-DotNet/Threads/CodeInterpreter.cs
+++ b/OpenAI-DotNet/Threads/CodeInterpreter.cs
@@ -13,6 +13,7 @@ namespace OpenAI.Threads
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("input")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Input { get; private set; }
 
         private List<CodeInterpreterOutputs> outputs;
@@ -24,6 +25,7 @@ namespace OpenAI.Threads
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("outputs")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public IReadOnlyList<CodeInterpreterOutputs> Outputs
         {
             get => outputs;

--- a/OpenAI-DotNet/Threads/CodeInterpreterOutputs.cs
+++ b/OpenAI-DotNet/Threads/CodeInterpreterOutputs.cs
@@ -24,6 +24,7 @@ namespace OpenAI.Threads
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("logs")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Logs { get; private set; }
 
         /// <summary>
@@ -31,6 +32,7 @@ namespace OpenAI.Threads
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("image")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public ImageFile Image { get; private set; }
 
         public void AppendFrom(CodeInterpreterOutputs other)

--- a/OpenAI-DotNet/Threads/FunctionCall.cs
+++ b/OpenAI-DotNet/Threads/FunctionCall.cs
@@ -18,6 +18,7 @@ namespace OpenAI.Threads
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("arguments")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Arguments { get; private set; }
 
         /// <summary>
@@ -25,6 +26,7 @@ namespace OpenAI.Threads
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("output")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Output { get; private set; }
 
         internal void AppendFrom(FunctionCall other)

--- a/OpenAI-DotNet/Threads/MessageResponse.cs
+++ b/OpenAI-DotNet/Threads/MessageResponse.cs
@@ -185,7 +185,7 @@ namespace OpenAI.Threads
             {
                 if (Id != other.Id)
                 {
-                    throw new InvalidOperationException("Attempting to append a different object than the original!");
+                    throw new InvalidOperationException($"Attempting to append a different object than the original! {Id} != {other.Id}");
                 }
             }
             else

--- a/OpenAI-DotNet/Threads/RunResponse.cs
+++ b/OpenAI-DotNet/Threads/RunResponse.cs
@@ -296,7 +296,7 @@ namespace OpenAI.Threads
             {
                 if (Id != other.Id)
                 {
-                    throw new InvalidOperationException("Attempting to append a different object than the original!");
+                    throw new InvalidOperationException($"Attempting to append a different object than the original! {Id} != {other.Id}");
                 }
             }
             else

--- a/OpenAI-DotNet/Threads/RunStepResponse.cs
+++ b/OpenAI-DotNet/Threads/RunStepResponse.cs
@@ -195,7 +195,7 @@ namespace OpenAI.Threads
             {
                 if (Id != other.Id)
                 {
-                    throw new InvalidOperationException("Attempting to append a different object than the original!");
+                    throw new InvalidOperationException($"Attempting to append a different object than the original! {Id} != {other.Id}");
                 }
             }
             else

--- a/OpenAI-DotNet/Threads/ThreadExtensions.cs
+++ b/OpenAI-DotNet/Threads/ThreadExtensions.cs
@@ -177,26 +177,42 @@ namespace OpenAI.Threads
 
         #region Runs
 
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public static async Task<RunResponse> CreateRunAsync(this ThreadResponse thread, CreateRunRequest request, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await thread.CreateRunAsync(request, async streamEvent =>
+            {
+                streamEventHandler?.Invoke(streamEvent);
+                await Task.CompletedTask;
+            }, cancellationToken);
+
         /// <summary>
         /// Create a run.
         /// </summary>
         /// <param name="thread"><see cref="ThreadResponse"/>.</param>
         /// <param name="request"><see cref="CreateRunRequest"/>.</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public static async Task<RunResponse> CreateRunAsync(this ThreadResponse thread, CreateRunRequest request = null, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public static async Task<RunResponse> CreateRunAsync(this ThreadResponse thread, CreateRunRequest request = null, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
             => await thread.Client.ThreadsEndpoint.CreateRunAsync(thread, request, streamEventHandler, cancellationToken).ConfigureAwait(false);
+
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public static async Task<RunResponse> CreateRunAsync(this ThreadResponse thread, AssistantResponse assistant, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await thread.CreateRunAsync(assistant, async streamEvent =>
+            {
+                streamEventHandler?.Invoke(streamEvent);
+                await Task.CompletedTask;
+            }, cancellationToken);
 
         /// <summary>
         /// Create a run.
         /// </summary>
         /// <param name="thread"><see cref="ThreadResponse"/>.</param>
         /// <param name="assistant">The <see cref="AssistantResponse"/> to use for the run.</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public static async Task<RunResponse> CreateRunAsync(this ThreadResponse thread, AssistantResponse assistant, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public static async Task<RunResponse> CreateRunAsync(this ThreadResponse thread, AssistantResponse assistant, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
         {
             var request = new CreateRunRequest(
                 assistant,
@@ -286,6 +302,14 @@ namespace OpenAI.Threads
             return result;
         }
 
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public static async Task<RunResponse> SubmitToolOutputsAsync(this RunResponse run, SubmitToolOutputsRequest request, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await run.SubmitToolOutputsAsync(request, async streamEvent =>
+            {
+                streamEventHandler?.Invoke(streamEvent);
+                await Task.CompletedTask;
+            }, cancellationToken);
+
         /// <summary>
         /// When a run has the status: "requires_action" and required_action.type is submit_tool_outputs,
         /// this endpoint can be used to submit the outputs from the tool calls once they're all completed.
@@ -293,11 +317,19 @@ namespace OpenAI.Threads
         /// </summary>
         /// <param name="run"><see cref="RunResponse"/> to submit outputs for.</param>
         /// <param name="request"><see cref="SubmitToolOutputsRequest"/>.</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public static async Task<RunResponse> SubmitToolOutputsAsync(this RunResponse run, SubmitToolOutputsRequest request, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public static async Task<RunResponse> SubmitToolOutputsAsync(this RunResponse run, SubmitToolOutputsRequest request, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
             => await run.Client.ThreadsEndpoint.SubmitToolOutputsAsync(run.ThreadId, run.Id, request, streamEventHandler, cancellationToken).ConfigureAwait(false);
+
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public static async Task<RunResponse> SubmitToolOutputsAsync(this RunResponse run, IEnumerable<ToolOutput> outputs, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await run.SubmitToolOutputsAsync(new SubmitToolOutputsRequest(outputs), async streamEvent =>
+            {
+                streamEventHandler?.Invoke(streamEvent);
+                await Task.CompletedTask;
+            }, cancellationToken);
 
         /// <summary>
         /// When a run has the status: "requires_action" and required_action.type is submit_tool_outputs,
@@ -306,10 +338,10 @@ namespace OpenAI.Threads
         /// </summary>
         /// <param name="run"><see cref="RunResponse"/> to submit outputs for.</param>
         /// <param name="outputs"><see cref="ToolOutput"/>s</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public static async Task<RunResponse> SubmitToolOutputsAsync(this RunResponse run, IEnumerable<ToolOutput> outputs, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public static async Task<RunResponse> SubmitToolOutputsAsync(this RunResponse run, IEnumerable<ToolOutput> outputs, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
             => await run.SubmitToolOutputsAsync(new SubmitToolOutputsRequest(outputs), streamEventHandler, cancellationToken).ConfigureAwait(false);
 
         /// <summary>

--- a/OpenAI-DotNet/Threads/ToolCall.cs
+++ b/OpenAI-DotNet/Threads/ToolCall.cs
@@ -34,6 +34,7 @@ namespace OpenAI.Threads
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("function")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public FunctionCall FunctionCall { get; private set; }
 
         /// <summary>
@@ -41,6 +42,7 @@ namespace OpenAI.Threads
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("code_interpreter")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public CodeInterpreter CodeInterpreter { get; private set; }
 
         /// <summary>
@@ -51,6 +53,7 @@ namespace OpenAI.Threads
         /// </remarks>
         [JsonInclude]
         [JsonPropertyName("file_search")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public IReadOnlyDictionary<string, object> FileSearch { get; private set; }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ Install-Package OpenAI-DotNet
 
 ### Table of Contents
 
-- [Authentication](#authentication) :new: :warning: :construction:
-- [OpenAIClient](#handling-openaiclient-and-httpclient-lifecycle)
+- [Authentication](#authentication)
 - [Azure OpenAI](#azure-openai)
   - [Azure Active Directory Authentication](#azure-active-directory-authentication)
 - [OpenAI API Proxy](#openai-api-proxy)
@@ -51,17 +50,17 @@ Install-Package OpenAI-DotNet
   - [List Models](#list-models)
   - [Retrieve Models](#retrieve-model)
   - [Delete Fine Tuned Model](#delete-fine-tuned-model)
-- [Assistants](#assistants) :new: :warning: :construction:
+- [Assistants](#assistants) :warning: :construction:
   - [List Assistants](#list-assistants)
   - [Create Assistant](#create-assistant)
   - [Retrieve Assistant](#retrieve-assistant)
   - [Modify Assistant](#modify-assistant)
   - [Delete Assistant](#delete-assistant)
-  - [Assistant Streaming](#assistant-streaming) :new:
-  - [Threads](#threads) :new: :warning: :construction:
+  - [Assistant Streaming](#assistant-streaming) :warning: :construction:
+  - [Threads](#threads) :warning: :construction:
     - [Create Thread](#create-thread)
     - [Create Thread and Run](#create-thread-and-run)
-      - [Streaming](#create-thread-and-run-streaming) :new:
+      - [Streaming](#create-thread-and-run-streaming) :warning: :construction:
     - [Retrieve Thread](#retrieve-thread)
     - [Modify Thread](#modify-thread)
     - [Delete Thread](#delete-thread)
@@ -73,29 +72,29 @@ Install-Package OpenAI-DotNet
     - [Thread Runs](#thread-runs)
       - [List Runs](#list-thread-runs)
       - [Create Run](#create-thread-run)
-        - [Streaming](#create-thread-run-streaming) :new:
+        - [Streaming](#create-thread-run-streaming) :warning: :construction:
       - [Retrieve Run](#retrieve-thread-run)
       - [Modify Run](#modify-thread-run)
       - [Submit Tool Outputs to Run](#thread-submit-tool-outputs-to-run)
       - [List Run Steps](#list-thread-run-steps)
       - [Retrieve Run Step](#retrieve-thread-run-step)
       - [Cancel Run](#cancel-thread-run)
-  - [Vector Stores](#vector-stores) :new:
-    - [List Vector Stores](#list-vector-stores) :new:
-    - [Create Vector Store](#create-vector-store) :new:
-    - [Retrieve Vector Store](#retrieve-vector-store) :new:
-    - [Modify Vector Store](#modify-vector-store) :new:
-    - [Delete Vector Store](#delete-vector-store) :new:
-    - [Vector Store Files](#vector-store-files) :new:
-      - [List Vector Store Files](#list-vector-store-files) :new:
-      - [Create Vector Store File](#create-vector-store-file) :new:
-      - [Retrieve Vector Store File](#retrieve-vector-store-file) :new:
-      - [Delete Vector Store File](#delete-vector-store-file) :new:
-    - [Vector Store File Batches](#vector-store-file-batches) :new:
-      - [Create Vector Store File Batch](#create-vector-store-file-batch) :new:
-      - [Retrieve Vector Store File Batch](#retrieve-vector-store-file-batch) :new:
-      - [List Files In Vector Store Batch](#list-files-in-vector-store-batch) :new:
-      - [Cancel Vector Store File Batch](#cancel-vector-store-file-batch) :new:
+  - [Vector Stores](#vector-stores)
+    - [List Vector Stores](#list-vector-stores)
+    - [Create Vector Store](#create-vector-store)
+    - [Retrieve Vector Store](#retrieve-vector-store)
+    - [Modify Vector Store](#modify-vector-store)
+    - [Delete Vector Store](#delete-vector-store)
+    - [Vector Store Files](#vector-store-files)
+      - [List Vector Store Files](#list-vector-store-files)
+      - [Create Vector Store File](#create-vector-store-file)
+      - [Retrieve Vector Store File](#retrieve-vector-store-file)
+      - [Delete Vector Store File](#delete-vector-store-file)
+    - [Vector Store File Batches](#vector-store-file-batches)
+      - [Create Vector Store File Batch](#create-vector-store-file-batch)
+      - [Retrieve Vector Store File Batch](#retrieve-vector-store-file-batch)
+      - [List Files In Vector Store Batch](#list-files-in-vector-store-batch)
+      - [Cancel Vector Store File Batch](#cancel-vector-store-file-batch)
 - [Chat](#chat)
   - [Chat Completions](#chat-completions)
   - [Streaming](#chat-streaming)
@@ -104,6 +103,7 @@ Install-Package OpenAI-DotNet
   - [Json Mode](#chat-json-mode)
 - [Audio](#audio)
   - [Create Speech](#create-speech)
+    - [Stream Speech](#stream-speech)
   - [Create Transcription](#create-transcription)
   - [Create Translation](#create-translation)
 - [Images](#images) :warning: :construction:
@@ -122,11 +122,11 @@ Install-Package OpenAI-DotNet
   - [Retrieve Fine Tune Job Info](#retrieve-fine-tune-job-info)
   - [Cancel Fine Tune Job](#cancel-fine-tune-job)
   - [List Fine Tune Job Events](#list-fine-tune-job-events)
-- [Batches](#batches) :new:
-  - [List Batches](#list-batches) :new:
-  - [Create Batch](#create-batch) :new:
-  - [Retrieve Batch](#retrieve-batch) :new:
-  - [Cancel Batch](#cancel-batch) :new:
+- [Batches](#batches)
+  - [List Batches](#list-batches)
+  - [Create Batch](#create-batch)
+  - [Retrieve Batch](#retrieve-batch)
+  - [Cancel Batch](#cancel-batch)
 - [Embeddings](#embeddings)
   - [Create Embedding](#create-embeddings)
 - [Moderations](#moderations)
@@ -476,7 +476,7 @@ Assert.IsTrue(isDeleted);
 #### [Assistant Streaming](https://platform.openai.com/docs/api-reference/assistants-streaming)
 
 > [!NOTE]
-> Assistant stream events can be easily added to existing thread calls by passing `Action<IServerSentEvent> streamEventHandler` callback to any existing method that supports streaming.
+> Assistant stream events can be easily added to existing thread calls by passing `Func<IServerSentEvent, Task> streamEventHandler` callback to any existing method that supports streaming.
 
 #### [Threads](https://platform.openai.com/docs/api-reference/threads)
 
@@ -526,7 +526,7 @@ var tools = new List<Tool>
 var assistantRequest = new CreateAssistantRequest(tools: tools, instructions: "You are a helpful weather assistant. Use the appropriate unit based on geographical location.");
 var assistant = await api.AssistantsEndpoint.CreateAssistantAsync(assistantRequest);
 ThreadResponse thread = null;
-async void StreamEventHandler(IServerSentEvent streamEvent)
+async Task StreamEventHandler(IServerSentEvent streamEvent)
 {
     switch (streamEvent)
     {
@@ -720,9 +720,10 @@ var assistant = await api.AssistantsEndpoint.CreateAssistantAsync(
         responseFormat: ChatResponseFormat.Json));
 var thread = await api.ThreadsEndpoint.CreateThreadAsync();
 var message = await thread.CreateMessageAsync("I need to solve the equation `3x + 11 = 14`. Can you help me?");
-var run = await thread.CreateRunAsync(assistant, streamEvent =>
+var run = await thread.CreateRunAsync(assistant, async streamEvent =>
 {
     Console.WriteLine(streamEvent.ToJsonString());
+    await Task.CompletedTask;
 });
 var messages = await thread.ListMessagesAsync();
 
@@ -1054,9 +1055,10 @@ var messages = new List<Message>
     new Message(Role.User, "Where was it played?"),
 };
 var chatRequest = new ChatRequest(messages);
-var response = await api.ChatEndpoint.StreamCompletionAsync(chatRequest, partialResponse =>
+var response = await api.ChatEndpoint.StreamCompletionAsync(chatRequest, async partialResponse =>
 {
     Console.Write(partialResponse.FirstChoice.Delta.ToString());
+    await Task.CompletedTask;
 });
 var choice = response.FirstChoice;
 Console.WriteLine($"[{choice.Index}] {choice.Message.Role}: {choice.Message} | Finish Reason: {choice.FinishReason}");


### PR DESCRIPTION
- Fixed streaming event race conditions where the subscriber to the stream would finish before steam events were executed
- Refactored streaming events callbacks from `Action<IServerSentEvent>` to `Func<IServerSentEvent, Task>`
- Added `Exception` data to `OpenAI.Error` response
- Added `ChatEndpoint.StreamCompletionAsync` with `Func<ChatResponse, Task>` overload