### PR TITLE
OpenAI-DotNet 8.1.2

### DIFF
--- a/OpenAI-DotNet/Common/Function.cs
+++ b/OpenAI-DotNet/Common/Function.cs
@@ -73,6 +73,12 @@ namespace OpenAI
             Parameters = JsonNode.Parse(parameters);
         }
 
+        internal Function(string name, JsonNode arguments)
+        {
+            Name = name;
+            Arguments = arguments;
+        }
+
         private Function(string name, string description, MethodInfo method, object instance = null)
         {
             if (!Regex.IsMatch(name, NameRegex))

--- a/OpenAI-DotNet/Common/Tool.cs
+++ b/OpenAI-DotNet/Common/Tool.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,6 +22,13 @@ namespace OpenAI
         {
             Function = function;
             Type = nameof(function);
+        }
+
+        public Tool(string toolCallId, string functionName, JsonNode functionArguments)
+        {
+            Function = new Function(functionName, arguments: functionArguments);
+            Type = "function";
+            Id = toolCallId;
         }
 
         public Tool(FileSearchOptions fileSearchOptions)

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -29,8 +29,10 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>8.1.1</Version>
+    <Version>8.2.0</Version>
     <PackageReleaseNotes>
+Version 8.2.0
+- Added constructor overloads to Tool and Function classes to support manually adding tool calls in the conversation history
 Version 8.1.1
 - Added overloads to Assistant streaming event callbacks to include event name: Func&lt;String, IServerSentEvent, Task&gt;
 Version 8.1.0

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -29,9 +29,9 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>8.2.0</Version>
+    <Version>8.1.2</Version>
     <PackageReleaseNotes>
-Version 8.2.0
+Version 8.1.2
 - Added constructor overloads to Tool and Function classes to support manually adding tool calls in the conversation history
 Version 8.1.1
 - Added overloads to Assistant streaming event callbacks to include event name: Func&lt;String, IServerSentEvent, Task&gt;


### PR DESCRIPTION
- Added constructor overloads to Tool and Function classes to support manually adding tool calls in the conversation history