### PR TITLE
Add TimeSpan Properties to BaseResponse for Rate Limit Headers

### DIFF
--- a/OpenAI-DotNet/Common/BaseResponse.cs
+++ b/OpenAI-DotNet/Common/BaseResponse.cs
@@ -113,6 +113,7 @@ namespace OpenAI
         private TimeSpan ConvertTimestampToTimespan(string timestamp)
         {
             Match match = timestampRegex.Match(timestamp);
+
             if (!match.Success)
             {
                 throw new ArgumentException($"Could not parse timestamp header. '{timestamp}'.");
@@ -125,23 +126,27 @@ namespace OpenAI
              *  negative impact for a missing hours segment because the capture groups are flagged as optional.
              */
             int hours = 0;
+
             if (match.Groups.ContainsKey("hour"))
             {
                 hours = int.Parse(match.Groups["hour"].Value.Replace("h", string.Empty));
             }
 
             int minutes = 0;
+
             if (match.Groups.ContainsKey("mins"))
             {
                 minutes = int.Parse(match.Groups["mins"].Value.Replace("m", string.Empty));
             }
 
             int seconds = 0;
+
             if (match.Groups.ContainsKey("secs"))
             {
                 seconds = int.Parse(match.Groups["secs"].Value.Replace("s", string.Empty));
             }
             int ms = 0;
+
             if (match.Groups.ContainsKey("ms"))
             {
                 ms = int.Parse(match.Groups["ms"].Value.Replace("ms", string.Empty));

--- a/OpenAI-DotNet/Common/BaseResponse.cs
+++ b/OpenAI-DotNet/Common/BaseResponse.cs
@@ -9,7 +9,6 @@ namespace OpenAI
 {
     public abstract class BaseResponse
     {
-
         /// <summary>
         /// The <see cref="OpenAIClient"/> this response was generated from.
         /// </summary>
@@ -87,8 +86,6 @@ namespace OpenAI
         /// </summary>
         [JsonIgnore]
         public TimeSpan ResetTokensTimespan => ConvertTimestampToTimespan(ResetTokens);
-
-
 
         /*
         * Regex Notes: 

--- a/OpenAI-DotNet/Common/BaseResponse.cs
+++ b/OpenAI-DotNet/Common/BaseResponse.cs
@@ -102,14 +102,14 @@ namespace OpenAI
              *  TimeSpan object for easier use.
              *  
              *  Regex Performance Notes, against 100k randomly generated timestamps:
-             *  Average performance: 0.0001ms
+             *  Average performance: 0.0003ms
              *  Best case: 0ms
-             *  Worst Case: 8ms
-             *  Total Time: 10ms
+             *  Worst Case: 15ms
+             *  Total Time: 30ms
              *  
              *  Inconsequential compute time
              */
-            Regex tsRegex = new Regex(@"^(?<hour>\d+h)?(?<mins>\d+m)?(?<secs>\d+s)?(?<ms>\d+ms)?");
+            Regex tsRegex = new Regex(@"^(?<hour>\d+h)?(?<mins>\d+m(?!s))?(?<secs>\d+s)?(?<ms>\d+ms)?");
             Match match = tsRegex.Match(timestamp);
             if (!match.Success)
             {

--- a/OpenAI-DotNet/Common/BaseResponse.cs
+++ b/OpenAI-DotNet/Common/BaseResponse.cs
@@ -72,6 +72,7 @@ namespace OpenAI
         /// <summary>
         /// The time until the rate limit (based on requests) resets to its initial state represented as a TimeSpan.
         /// </summary>
+        [JsonIgnore]
         public TimeSpan ResetRequestsTimespan { get => ConvertTimestampToTimespan(ResetRequests); }
 
         /// <summary>

--- a/OpenAI-DotNet/Common/BaseResponse.cs
+++ b/OpenAI-DotNet/Common/BaseResponse.cs
@@ -104,7 +104,6 @@ namespace OpenAI
         */
         private readonly Regex timestampRegex = new Regex(@"^(?<hour>\d+h)?(?<mins>\d+m(?!s))?(?<secs>\d+s)?(?<ms>\d+ms)?");
 
-
         /// <summary>
         /// Takes a timestamp recieved from a OpenAI response header and converts to a TimeSpan
         /// </summary>


### PR DESCRIPTION
# Abstract

The current headers return strings such as `12m30s`. If you want to consume this data, it needs to be parsed into a more usable format. This PR will add properties to the abstract class BaseResponse that will parse the header strings into something more useful.

# Changes
- Two new public readonly properties of type TimeSpan have been added to BaseResponse, `ResetTokensTimespan ` and `ResetTokensTimespan `
- The original properties have not been changed in order to avoid any breaking changes for downstream projects that may be relying on them.

# Testing Methods
Since regex done poorly can be a massive hindrance in terms of performance, the regex's performance has been tested using a separate project. The regex was run through 100k randomly generated timestamps. The code can be found [here](https://github.com/RealStillkill/OpenAI-DotNet-RegexMetrics). The compute time of the regex was negligible.

This change was based on an extension method used in a private project. It has not produced any problems during its usage in the other project.