### PR TITLE
fix:  domain like https://domain not allow

### DIFF
--- a/OpenAI-DotNet/Authentication/OpenAIClientSettings.cs
+++ b/OpenAI-DotNet/Authentication/OpenAIClientSettings.cs
@@ -56,15 +56,19 @@ namespace OpenAI
                 apiVersion = DefaultOpenAIApiVersion;
             }
 
-            ResourceName = domain.Contains(Http)
-                ? domain
-                : $"{Https}{domain}";
-
-            if (domain.Contains(Http))
+            var httpSchema = Https;
+            if (domain.StartsWith(Http))
             {
+                httpSchema = Http;
                 domain = domain.Replace(Http, string.Empty);
+            }
+            else if (domain.StartsWith(Https))
+            {
+                httpSchema = Https;
                 domain = domain.Replace(Https, string.Empty);
             }
+
+            ResourceName = $"{httpSchema}{domain}";
 
             ApiVersion = apiVersion;
             DeploymentId = string.Empty;


### PR DESCRIPTION
the following use case where
```csharp
var client = new OpenAIClient(new OpenAIAuthentication(key), new OpenAIClientSettings("https://domain"));
```
does not work, while both `domain` and `http://domain` work fine. This does not reflect the consistency of the API.

After modification, parameters like 
- `http://domain.xxx`
- `domain.xxx`
- `https://domain.xxx`

are both allowed.

