### PR TITLE
Add customizable client timeout

### DIFF
--- a/OpenAI-DotNet/Authentication/OpenAIClientSettings.cs
+++ b/OpenAI-DotNet/Authentication/OpenAIClientSettings.cs
@@ -18,6 +18,8 @@ namespace OpenAI
         internal const string DefaultOpenAIApiVersion = "v1";
         internal const string AzureOpenAIDomain = "openai.azure.com";
         internal const string DefaultAzureApiVersion = "2023-05-01";
+        private TimeSpan DefaultTimeout = TimeSpan.FromSeconds(100);
+        private TimeSpan? TimeoutOverride = null;
 
         /// <summary>
         /// Creates a new instance of <see cref="OpenAIClientSettings"/> for use with OpenAI.
@@ -120,6 +122,12 @@ namespace OpenAI
             UseOAuthAuthentication = useActiveDirectoryAuthentication;
         }
 
+        public OpenAIClientSettings OverrideClientTimeout(TimeSpan timeout)
+        {
+            TimeoutOverride = timeout;
+            return this;
+        }
+
         public string ResourceName { get; }
 
         public string DeploymentId { get; }
@@ -133,6 +141,18 @@ namespace OpenAI
         internal string BaseWebSocketUrlFormat { get; }
 
         internal bool UseOAuthAuthentication { get; }
+
+        internal TimeSpan Timeout
+        {
+            get
+            {
+                if (TimeoutOverride.HasValue)
+                {
+                    return TimeoutOverride.Value;
+                }
+                return DefaultTimeout;
+            }
+        }
 
         public bool IsAzureOpenAI => BaseRequestUrlFormat.Contains(AzureOpenAIDomain);
 

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -267,6 +267,8 @@ namespace OpenAI
                 client.DefaultRequestHeaders.Add("OpenAI-Project", OpenAIAuthentication.ProjectId);
             }
 
+            client.Timeout = OpenAIClientSettings.Timeout;
+
             return client;
         }
 


### PR DESCRIPTION
### Abstract
A recent OpenAI outage has resulted in long wait times for APIs dependent on this library. This library uses the [default HttpClient timeout of 100 seconds](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.timeout), which in turn caused the end users to wait 100 seconds for any kind of failure to occur. Fail fast they say.


The only way to override this would have been to supply our own HttpClient, which some users may not wish to do. 
A method was chosen instead of a constructor parameter because this would result in less editing of existing stable code and would prevent breaking changes where some existing optional parameters would need to be rearranged. The default timeout will remain the same.

### Changes
- Add `OverrideClientTimeout(TimeSpan timeout)` to OpenAIClientSettings