### PR TITLE
OpenAI-DotNet 8.6.0

### DIFF
--- a/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
@@ -184,13 +184,11 @@ namespace OpenAI.Tests
             try
             {
                 Assert.IsNotNull(OpenAIClient.RealtimeEndpoint);
-                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
-                var wasGoodbyeCalled = false;
+                var cts = new CancellationTokenSource();
                 var tools = new List<Tool>
                 {
                     Tool.FromFunc("goodbye", () =>
                     {
-                        wasGoodbyeCalled = true;
                         cts.Cancel();
                         return "Goodbye!";
                     })
@@ -241,7 +239,6 @@ namespace OpenAI.Tests
                 }
 
                 await responseTask.ConfigureAwait(true);
-                Assert.IsTrue(wasGoodbyeCalled);
             }
             catch (Exception e)
             {

--- a/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
@@ -35,16 +35,16 @@ namespace OpenAI.Tests
                 var configuration = new SessionConfiguration(Model.GPT4oRealtime, tools: tools);
                 session = await OpenAIClient.RealtimeEndpoint.CreateSessionAsync(configuration, cts.Token);
                 Assert.IsNotNull(session);
-                Assert.IsNotNull(session.Options);
+                Assert.IsNotNull(session.Configuration);
                 Assert.AreEqual(Model.GPT4oRealtime.Id, configuration.Model);
-                Assert.AreEqual(configuration.Model, session.Options.Model);
+                Assert.AreEqual(configuration.Model, session.Configuration.Model);
                 Assert.IsNotNull(configuration.Tools);
                 Assert.IsNotEmpty(configuration.Tools);
                 Assert.AreEqual(1, configuration.Tools.Count);
-                Assert.AreEqual(configuration.Tools.Count, session.Options.Tools.Count);
-                Assert.AreEqual(configuration.Tools[0].Name, session.Options.Tools[0].Name);
+                Assert.AreEqual(configuration.Tools.Count, session.Configuration.Tools.Count);
+                Assert.AreEqual(configuration.Tools[0].Name, session.Configuration.Tools[0].Name);
                 Assert.AreEqual(Modality.Audio | Modality.Text, configuration.Modalities);
-                Assert.AreEqual(Modality.Audio | Modality.Text, session.Options.Modalities);
+                Assert.AreEqual(Modality.Audio | Modality.Text, session.Configuration.Modalities);
                 var responseTask = session.ReceiveUpdatesAsync<IServerEvent>(SessionEvents, cts.Token);
 
                 await session.SendAsync(new ConversationItemCreateRequest("Hello!"), cts.Token);
@@ -112,19 +112,19 @@ namespace OpenAI.Tests
                     })
                 };
 
-                var options = new SessionConfiguration(Model.GPT4oRealtime, tools: tools);
-                session = await OpenAIClient.RealtimeEndpoint.CreateSessionAsync(options, cts.Token);
+                var configuration = new SessionConfiguration(Model.GPT4oRealtime, tools: tools);
+                session = await OpenAIClient.RealtimeEndpoint.CreateSessionAsync(configuration, cts.Token);
                 Assert.IsNotNull(session);
-                Assert.IsNotNull(session.Options);
-                Assert.AreEqual(Model.GPT4oRealtime.Id, options.Model);
-                Assert.AreEqual(options.Model, session.Options.Model);
-                Assert.IsNotNull(options.Tools);
-                Assert.IsNotEmpty(options.Tools);
-                Assert.AreEqual(1, options.Tools.Count);
-                Assert.AreEqual(options.Tools.Count, session.Options.Tools.Count);
-                Assert.AreEqual(options.Tools[0].Name, session.Options.Tools[0].Name);
-                Assert.AreEqual(Modality.Audio | Modality.Text, options.Modalities);
-                Assert.AreEqual(Modality.Audio | Modality.Text, session.Options.Modalities);
+                Assert.IsNotNull(session.Configuration);
+                Assert.AreEqual(Model.GPT4oRealtime.Id, configuration.Model);
+                Assert.AreEqual(configuration.Model, session.Configuration.Model);
+                Assert.IsNotNull(configuration.Tools);
+                Assert.IsNotEmpty(configuration.Tools);
+                Assert.AreEqual(1, configuration.Tools.Count);
+                Assert.AreEqual(configuration.Tools.Count, session.Configuration.Tools.Count);
+                Assert.AreEqual(configuration.Tools[0].Name, session.Configuration.Tools[0].Name);
+                Assert.AreEqual(Modality.Audio | Modality.Text, configuration.Modalities);
+                Assert.AreEqual(Modality.Audio | Modality.Text, session.Configuration.Modalities);
 
                 await foreach (var @event in session.ReceiveUpdatesAsync<IServerEvent>(cts.Token).ConfigureAwait(false))
                 {

--- a/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
@@ -26,8 +26,8 @@ namespace OpenAI.Tests
                 {
                     Tool.FromFunc("goodbye", () =>
                     {
-                        cts.Cancel();
                         wasGoodbyeCalled = true;
+                        cts.Cancel();
                         return "Goodbye!";
                     })
                 };
@@ -190,8 +190,8 @@ namespace OpenAI.Tests
                 {
                     Tool.FromFunc("goodbye", () =>
                     {
-                        cts.Cancel();
                         wasGoodbyeCalled = true;
+                        cts.Cancel();
                         return "Goodbye!";
                     })
                 };
@@ -241,7 +241,6 @@ namespace OpenAI.Tests
                 }
 
                 await responseTask.ConfigureAwait(true);
-                await Task.Delay(500, CancellationToken.None);
                 Assert.IsTrue(wasGoodbyeCalled);
             }
             catch (Exception e)

--- a/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
@@ -212,6 +212,7 @@ namespace OpenAI.Tests
                 Assert.AreEqual(configuration.Tools[0].Name, session.Configuration.Tools[0].Name);
                 Assert.AreEqual(Modality.Audio | Modality.Text, configuration.Modalities);
                 Assert.AreEqual(Modality.Audio | Modality.Text, session.Configuration.Modalities);
+                Assert.AreEqual(TurnDetectionType.Disabled, session.Configuration.VoiceActivityDetectionSettings.Type);
                 var responseTask = session.ReceiveUpdatesAsync<IServerEvent>(SessionEvents, cts.Token);
 
                 await session.SendAsync(new ConversationItemCreateRequest("Hello!"), cts.Token);
@@ -240,6 +241,7 @@ namespace OpenAI.Tests
                 }
 
                 await responseTask.ConfigureAwait(true);
+                await Task.Delay(500, cts.Token);
                 Assert.IsTrue(wasGoodbyeCalled);
             }
             catch (Exception e)

--- a/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
@@ -196,7 +196,10 @@ namespace OpenAI.Tests
                     })
                 };
 
-                var configuration = new SessionConfiguration(Model.GPT4oRealtime, tools: tools, turnDetectionSettings: VoiceActivityDetectionSettings.Disabled());
+                var configuration = new SessionConfiguration(
+                    model: Model.GPT4oRealtime,
+                    tools: tools,
+                    turnDetectionSettings: VoiceActivityDetectionSettings.Disabled());
                 session = await OpenAIClient.RealtimeEndpoint.CreateSessionAsync(configuration, cts.Token);
                 Assert.IsNotNull(session);
                 Assert.IsNotNull(session.Configuration);

--- a/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
@@ -32,18 +32,18 @@ namespace OpenAI.Tests
                     })
                 };
 
-                var options = new SessionConfiguration(Model.GPT4oRealtime, tools: tools);
-                session = await OpenAIClient.RealtimeEndpoint.CreateSessionAsync(options, cts.Token);
+                var configuration = new SessionConfiguration(Model.GPT4oRealtime, tools: tools);
+                session = await OpenAIClient.RealtimeEndpoint.CreateSessionAsync(configuration, cts.Token);
                 Assert.IsNotNull(session);
                 Assert.IsNotNull(session.Options);
-                Assert.AreEqual(Model.GPT4oRealtime.Id, options.Model);
-                Assert.AreEqual(options.Model, session.Options.Model);
-                Assert.IsNotNull(options.Tools);
-                Assert.IsNotEmpty(options.Tools);
-                Assert.AreEqual(1, options.Tools.Count);
-                Assert.AreEqual(options.Tools.Count, session.Options.Tools.Count);
-                Assert.AreEqual(options.Tools[0].Name, session.Options.Tools[0].Name);
-                Assert.AreEqual(Modality.Audio | Modality.Text, options.Modalities);
+                Assert.AreEqual(Model.GPT4oRealtime.Id, configuration.Model);
+                Assert.AreEqual(configuration.Model, session.Options.Model);
+                Assert.IsNotNull(configuration.Tools);
+                Assert.IsNotEmpty(configuration.Tools);
+                Assert.AreEqual(1, configuration.Tools.Count);
+                Assert.AreEqual(configuration.Tools.Count, session.Options.Tools.Count);
+                Assert.AreEqual(configuration.Tools[0].Name, session.Options.Tools[0].Name);
+                Assert.AreEqual(Modality.Audio | Modality.Text, configuration.Modalities);
                 Assert.AreEqual(Modality.Audio | Modality.Text, session.Options.Modalities);
                 var responseTask = session.ReceiveUpdatesAsync<IServerEvent>(SessionEvents, cts.Token);
 

--- a/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
@@ -13,7 +13,7 @@ namespace OpenAI.Tests
     internal class TestFixture_13_Realtime : AbstractTestFixture
     {
         [Test]
-        public async Task Test_01_RealtimeSession()
+        public async Task Test_01_01_RealtimeSession()
         {
             RealtimeSession session = null;
 
@@ -93,7 +93,7 @@ namespace OpenAI.Tests
         }
 
         [Test]
-        public async Task Test_01_RealtimeSession_IAsyncEnumerable()
+        public async Task Test_01_02_RealtimeSession_IAsyncEnumerable()
         {
             RealtimeSession session = null;
 
@@ -156,6 +156,87 @@ namespace OpenAI.Tests
                     }
                 }
 
+                Assert.IsTrue(wasGoodbyeCalled);
+            }
+            catch (Exception e)
+            {
+                switch (e)
+                {
+                    case ObjectDisposedException:
+                        // ignore
+                        break;
+                    default:
+                        Console.WriteLine(e);
+                        throw;
+                }
+            }
+            finally
+            {
+                session?.Dispose();
+            }
+        }
+
+        [Test]
+        public async Task Test_02_RealtimeSession_VAD_Disabled()
+        {
+            RealtimeSession session = null;
+
+            try
+            {
+                Assert.IsNotNull(OpenAIClient.RealtimeEndpoint);
+                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+                var wasGoodbyeCalled = false;
+                var tools = new List<Tool>
+                {
+                    Tool.FromFunc("goodbye", () =>
+                    {
+                        cts.Cancel();
+                        wasGoodbyeCalled = true;
+                        return "Goodbye!";
+                    })
+                };
+
+                var configuration = new SessionConfiguration(Model.GPT4oRealtime, tools: tools, turnDetectionSettings: VoiceActivityDetectionSettings.Disabled());
+                session = await OpenAIClient.RealtimeEndpoint.CreateSessionAsync(configuration, cts.Token);
+                Assert.IsNotNull(session);
+                Assert.IsNotNull(session.Configuration);
+                Assert.AreEqual(Model.GPT4oRealtime.Id, configuration.Model);
+                Assert.AreEqual(configuration.Model, session.Configuration.Model);
+                Assert.IsNotNull(configuration.Tools);
+                Assert.IsNotEmpty(configuration.Tools);
+                Assert.AreEqual(1, configuration.Tools.Count);
+                Assert.AreEqual(configuration.Tools.Count, session.Configuration.Tools.Count);
+                Assert.AreEqual(configuration.Tools[0].Name, session.Configuration.Tools[0].Name);
+                Assert.AreEqual(Modality.Audio | Modality.Text, configuration.Modalities);
+                Assert.AreEqual(Modality.Audio | Modality.Text, session.Configuration.Modalities);
+                var responseTask = session.ReceiveUpdatesAsync<IServerEvent>(SessionEvents, cts.Token);
+
+                await session.SendAsync(new ConversationItemCreateRequest("Hello!"), cts.Token);
+                await session.SendAsync(new CreateResponseRequest(), cts.Token);
+                await session.SendAsync(new InputAudioBufferAppendRequest(new ReadOnlyMemory<byte>(new byte[1024 * 8])), cts.Token);
+                await session.SendAsync(new InputAudioBufferCommitRequest(), cts.Token);
+                await session.SendAsync(new ConversationItemCreateRequest("Goodbye!"), cts.Token);
+                await session.SendAsync(new CreateResponseRequest(), cts.Token);
+
+                void SessionEvents(IServerEvent @event)
+                {
+                    switch (@event)
+                    {
+                        case ResponseAudioTranscriptResponse transcriptResponse:
+                            Console.WriteLine(transcriptResponse.ToString());
+                            break;
+                        case ResponseFunctionCallArgumentsResponse functionCallResponse:
+                            if (functionCallResponse.IsDone)
+                            {
+                                ToolCall toolCall = functionCallResponse;
+                                toolCall.InvokeFunction();
+                            }
+
+                            break;
+                    }
+                }
+
+                await responseTask.ConfigureAwait(true);
                 Assert.IsTrue(wasGoodbyeCalled);
             }
             catch (Exception e)

--- a/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
@@ -20,7 +20,7 @@ namespace OpenAI.Tests
             try
             {
                 Assert.IsNotNull(OpenAIClient.RealtimeEndpoint);
-                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
                 var wasGoodbyeCalled = false;
                 var tools = new List<Tool>
                 {
@@ -100,7 +100,7 @@ namespace OpenAI.Tests
             try
             {
                 Assert.IsNotNull(OpenAIClient.RealtimeEndpoint);
-                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
                 var wasGoodbyeCalled = false;
                 var tools = new List<Tool>
                 {
@@ -184,7 +184,7 @@ namespace OpenAI.Tests
             try
             {
                 Assert.IsNotNull(OpenAIClient.RealtimeEndpoint);
-                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
                 var wasGoodbyeCalled = false;
                 var tools = new List<Tool>
                 {

--- a/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
@@ -212,7 +212,7 @@ namespace OpenAI.Tests
                 Assert.AreEqual(configuration.Tools[0].Name, session.Configuration.Tools[0].Name);
                 Assert.AreEqual(Modality.Audio | Modality.Text, configuration.Modalities);
                 Assert.AreEqual(Modality.Audio | Modality.Text, session.Configuration.Modalities);
-                Assert.AreEqual(TurnDetectionType.Disabled, session.Configuration.VoiceActivityDetectionSettings.Type);
+                Assert.IsNull(session.Configuration.VoiceActivityDetectionSettings);
                 var responseTask = session.ReceiveUpdatesAsync<IServerEvent>(SessionEvents, cts.Token);
 
                 await session.SendAsync(new ConversationItemCreateRequest("Hello!"), cts.Token);
@@ -241,7 +241,7 @@ namespace OpenAI.Tests
                 }
 
                 await responseTask.ConfigureAwait(true);
-                await Task.Delay(500, cts.Token);
+                await Task.Delay(500, CancellationToken.None);
                 Assert.IsTrue(wasGoodbyeCalled);
             }
             catch (Exception e)

--- a/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
@@ -32,7 +32,7 @@ namespace OpenAI.Tests
                     })
                 };
 
-                var options = new Options(Model.GPT4oRealtime, tools: tools);
+                var options = new SessionConfiguration(Model.GPT4oRealtime, tools: tools);
                 session = await OpenAIClient.RealtimeEndpoint.CreateSessionAsync(options, cts.Token);
                 Assert.IsNotNull(session);
                 Assert.IsNotNull(session.Options);
@@ -112,7 +112,7 @@ namespace OpenAI.Tests
                     })
                 };
 
-                var options = new Options(Model.GPT4oRealtime, tools: tools);
+                var options = new SessionConfiguration(Model.GPT4oRealtime, tools: tools);
                 session = await OpenAIClient.RealtimeEndpoint.CreateSessionAsync(options, cts.Token);
                 Assert.IsNotNull(session);
                 Assert.IsNotNull(session.Options);

--- a/OpenAI-DotNet/Extensions/VoiceActivityDetectionSettingsConverter.cs
+++ b/OpenAI-DotNet/Extensions/VoiceActivityDetectionSettingsConverter.cs
@@ -1,0 +1,34 @@
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using OpenAI.Realtime;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenAI
+{
+    internal class VoiceActivityDetectionSettingsConverter : JsonConverter<VoiceActivityDetectionSettings>
+    {
+        public override VoiceActivityDetectionSettings Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.TokenType == JsonTokenType.Null
+                ? new VoiceActivityDetectionSettings(TurnDetectionType.Disabled)
+                : JsonSerializer.Deserialize<VoiceActivityDetectionSettings>(ref reader, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, VoiceActivityDetectionSettings value, JsonSerializerOptions options)
+        {
+            switch (value.Type)
+            {
+                case TurnDetectionType.Disabled:
+                    writer.WriteNullValue();
+                    break;
+                case TurnDetectionType.Server_VAD:
+                    JsonSerializer.Serialize(writer, value, options);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+}

--- a/OpenAI-DotNet/Extensions/VoiceActivityDetectionSettingsConverter.cs
+++ b/OpenAI-DotNet/Extensions/VoiceActivityDetectionSettingsConverter.cs
@@ -12,7 +12,7 @@ namespace OpenAI
         public override VoiceActivityDetectionSettings Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.TokenType == JsonTokenType.Null
-                ? new VoiceActivityDetectionSettings(TurnDetectionType.Disabled)
+                ? VoiceActivityDetectionSettings.Disabled()
                 : JsonSerializer.Deserialize<VoiceActivityDetectionSettings>(ref reader, options);
         }
 
@@ -23,11 +23,10 @@ namespace OpenAI
                 case TurnDetectionType.Disabled:
                     writer.WriteNullValue();
                     break;
+                default:
                 case TurnDetectionType.Server_VAD:
                     JsonSerializer.Serialize(writer, value, options);
                     break;
-                default:
-                    throw new ArgumentOutOfRangeException();
             }
         }
     }

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -29,8 +29,12 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>8.5.4</Version>
+    <Version>8.6.0</Version>
     <PackageReleaseNotes>
+Version 8.6.0
+- Deprecated OpenAI.Realtime.Options
+- Added OpenAI.Realtime.RealtimeOptions to specify the options of the RealtimeSession
+- Added OpenAI.Realtime.RealtimeResponseCreateParams to specify the options of the CreateResponseRequest
 Version 8.5.4
 - Update ChatRequest to support o3 series reasoning models
 Version 8.5.3

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -35,6 +35,8 @@ Version 8.6.0
 - Deprecated OpenAI.Realtime.Options
 - Added OpenAI.Realtime.SessionConfiguration to specify the options of the RealtimeSession when creating a new session
 - Added OpenAI.Realtime.RealtimeResponseCreateParams to specify the options of the CreateResponseRequest
+- Added VoiceActivityDetectionSettingsConverter to better handle disabled voice activity detection
+- Added VoiceActivityDetectionSettings.CreateResponse property
 Version 8.5.4
 - Update ChatRequest to support o3 series reasoning models
 Version 8.5.3

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -33,7 +33,7 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <PackageReleaseNotes>
 Version 8.6.0
 - Deprecated OpenAI.Realtime.Options
-- Added OpenAI.Realtime.RealtimeOptions to specify the options of the RealtimeSession
+- Added OpenAI.Realtime.SessionConfiguration to specify the options of the RealtimeSession when creating a new session
 - Added OpenAI.Realtime.RealtimeResponseCreateParams to specify the options of the CreateResponseRequest
 Version 8.5.4
 - Update ChatRequest to support o3 series reasoning models

--- a/OpenAI-DotNet/Realtime/ConversationItem.cs
+++ b/OpenAI-DotNet/Realtime/ConversationItem.cs
@@ -35,12 +35,12 @@ namespace OpenAI.Realtime
         }
 
         public ConversationItem(Role role, RealtimeContent content)
-            : this(role, new[] { content })
+            : this(role, [content])
         {
         }
 
         public ConversationItem(RealtimeContent content)
-            : this(Role.User, new[] { content })
+            : this(Role.User, [content])
         {
         }
 
@@ -82,7 +82,7 @@ namespace OpenAI.Realtime
         [JsonPropertyName("type")]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
         [JsonConverter(typeof(Extensions.JsonStringEnumConverter<ConversationItemType>))]
-        public ConversationItemType Type { get; private set; }
+        public ConversationItemType Type { get; internal set; }
 
         /// <summary>
         /// The status of the item ("completed", "in_progress", "incomplete").

--- a/OpenAI-DotNet/Realtime/ConversationItem.cs
+++ b/OpenAI-DotNet/Realtime/ConversationItem.cs
@@ -68,14 +68,6 @@ namespace OpenAI.Realtime
         public string Id { get; private set; }
 
         /// <summary>
-        /// The object type, must be "realtime.item".
-        /// </summary>
-        [JsonInclude]
-        [JsonPropertyName("object")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public string Object { get; private set; }
-
-        /// <summary>
         /// The type of the item ("message", "function_call", "function_call_output").
         /// </summary>
         [JsonInclude]
@@ -83,6 +75,14 @@ namespace OpenAI.Realtime
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
         [JsonConverter(typeof(Extensions.JsonStringEnumConverter<ConversationItemType>))]
         public ConversationItemType Type { get; internal set; }
+
+        /// <summary>
+        /// The object type, must be "realtime.item".
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("object")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string Object { get; private set; }
 
         /// <summary>
         /// The status of the item ("completed", "in_progress", "incomplete").

--- a/OpenAI-DotNet/Realtime/ConversationItemType.cs
+++ b/OpenAI-DotNet/Realtime/ConversationItemType.cs
@@ -11,6 +11,8 @@ namespace OpenAI.Realtime
         [EnumMember(Value = "function_call")]
         FunctionCall,
         [EnumMember(Value = "function_call_output")]
-        FunctionCallOutput
+        FunctionCallOutput,
+        [EnumMember(Value = "item_reference")]
+        ItemReference
     }
 }

--- a/OpenAI-DotNet/Realtime/ConversationResponseType.cs
+++ b/OpenAI-DotNet/Realtime/ConversationResponseType.cs
@@ -1,0 +1,14 @@
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.Serialization;
+
+namespace OpenAI.Realtime
+{
+    public enum ConversationResponseType
+    {
+        [EnumMember(Value = "auto")]
+        Auto = 0,
+        [EnumMember(Value = "none")]
+        None = 1
+    }
+}

--- a/OpenAI-DotNet/Realtime/CreateResponseRequest.cs
+++ b/OpenAI-DotNet/Realtime/CreateResponseRequest.cs
@@ -25,8 +25,8 @@ namespace OpenAI.Realtime
         }
 
         /// <summary>
-        /// Constructor.
         /// </summary>
+        /// <param name="options"></param>
         public CreateResponseRequest(RealtimeResponseCreateParams options)
         {
             Options = options;

--- a/OpenAI-DotNet/Realtime/CreateResponseRequest.cs
+++ b/OpenAI-DotNet/Realtime/CreateResponseRequest.cs
@@ -21,6 +21,7 @@ namespace OpenAI.Realtime
         [Obsolete("Use the constructor that takes RealtimeResponseCreateParams.")]
         public CreateResponseRequest(Options options)
         {
+            Options = options;
         }
 
         /// <summary>

--- a/OpenAI-DotNet/Realtime/CreateResponseRequest.cs
+++ b/OpenAI-DotNet/Realtime/CreateResponseRequest.cs
@@ -18,15 +18,12 @@ namespace OpenAI.Realtime
     {
         public CreateResponseRequest() { }
 
-        [Obsolete("Use the constructor that takes RealtimeResponseCreateParams.")]
-        public CreateResponseRequest(Options options)
-        {
-            Options = options;
-        }
-
         /// <summary>
+        /// Constructor.
         /// </summary>
-        /// <param name="options"></param>
+        /// <param name="options">
+        /// Create a new Realtime response with these parameters.
+        /// </param>
         public CreateResponseRequest(RealtimeResponseCreateParams options)
         {
             Options = options;

--- a/OpenAI-DotNet/Realtime/CreateResponseRequest.cs
+++ b/OpenAI-DotNet/Realtime/CreateResponseRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Text.Json.Serialization;
 
 namespace OpenAI.Realtime
@@ -17,11 +18,15 @@ namespace OpenAI.Realtime
     {
         public CreateResponseRequest() { }
 
+        [Obsolete("Use the constructor that takes RealtimeResponseCreateParams.")]
+        public CreateResponseRequest(Options options)
+        {
+        }
+
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="options">Inference configuration <see cref="Realtime.Options"/> to override the <see cref="RealtimeSession.Options"/> for this response only.</param>
-        public CreateResponseRequest(Options options)
+        public CreateResponseRequest(RealtimeResponseCreateParams options)
         {
             Options = options;
         }
@@ -38,6 +43,6 @@ namespace OpenAI.Realtime
 
         [JsonInclude]
         [JsonPropertyName("response")]
-        public Options Options { get; private set; }
+        public RealtimeResponseCreateParams Options { get; private set; }
     }
 }

--- a/OpenAI-DotNet/Realtime/Options.cs
+++ b/OpenAI-DotNet/Realtime/Options.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization;
 
 namespace OpenAI.Realtime
 {
-    [Obsolete("use SessionConfiguration")]
+    [Obsolete("use SessionConfiguration or RealtimeResponseCreateParams")]
     public sealed class Options
     {
         public static implicit operator SessionConfiguration(Options options)
@@ -21,6 +21,17 @@ namespace OpenAI.Realtime
                 options.OutputAudioFormat,
                 options.InputAudioTranscriptionSettings,
                 options.VoiceActivityDetectionSettings,
+                options.Tools,
+                options.ToolChoice,
+                options.Temperature,
+                options.MaxResponseOutputTokens);
+
+        public static implicit operator RealtimeResponseCreateParams(Options options)
+            => new(
+                options.Modalities,
+                options.Instructions,
+                options.Voice,
+                options.OutputAudioFormat,
                 options.Tools,
                 options.ToolChoice,
                 options.Temperature,

--- a/OpenAI-DotNet/Realtime/Options.cs
+++ b/OpenAI-DotNet/Realtime/Options.cs
@@ -182,6 +182,7 @@ namespace OpenAI.Realtime
 
         [JsonInclude]
         [JsonPropertyName("turn_detection")]
+        [JsonConverter(typeof(VoiceActivityDetectionSettingsConverter))]
         public VoiceActivityDetectionSettings VoiceActivityDetectionSettings { get; private set; }
 
         [JsonInclude]

--- a/OpenAI-DotNet/Realtime/RealtimeContent.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeContent.cs
@@ -12,11 +12,20 @@ namespace OpenAI.Realtime
         public RealtimeContent(string text, RealtimeContentType type)
         {
             Type = type;
-            Text = type switch
+            switch (type)
             {
-                RealtimeContentType.InputText or RealtimeContentType.Text => text,
-                _ => throw new ArgumentException($"Invalid content type {type} for text content")
-            };
+                case RealtimeContentType.InputText or RealtimeContentType.Text:
+                    Text = text;
+                    break;
+                case RealtimeContentType.InputAudio or RealtimeContentType.Audio:
+                    Audio = text;
+                    break;
+                case RealtimeContentType.ItemReference:
+                    Id = text;
+                    break;
+                default:
+                    throw new ArgumentException($"Invalid content type {type} for text content");
+            }
         }
 
         public RealtimeContent(ReadOnlyMemory<byte> audioData, RealtimeContentType type, string transcript = null)
@@ -47,7 +56,16 @@ namespace OpenAI.Realtime
         }
 
         /// <summary>
-        /// The content type ("text", "audio", "input_text", "input_audio").
+        /// ID of a previous conversation item to reference (for `item_reference` content types in `response.create` events).
+        /// These can reference both client and server created items.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string Id { get; private set; }
+
+        /// <summary>
+        /// The content type (`input_text`, `input_audio`, `item_reference`, `text`).
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("type")]
@@ -56,7 +74,7 @@ namespace OpenAI.Realtime
         public RealtimeContentType Type { get; private set; }
 
         /// <summary>
-        /// The text content.
+        /// The text content, used for `input_text` and `text` content types.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("text")]
@@ -64,7 +82,7 @@ namespace OpenAI.Realtime
         public string Text { get; private set; }
 
         /// <summary>
-        /// Base64-encoded audio data.
+        /// Base64-encoded audio bytes, used for `input_audio` content type.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("audio")]
@@ -72,7 +90,7 @@ namespace OpenAI.Realtime
         public string Audio { get; private set; }
 
         /// <summary>
-        /// The transcript of the audio.
+        /// The transcript of the audio, used for `input_audio` content type.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("transcript")]

--- a/OpenAI-DotNet/Realtime/RealtimeContentType.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeContentType.cs
@@ -13,6 +13,8 @@ namespace OpenAI.Realtime
         [EnumMember(Value = "input_text")]
         InputText,
         [EnumMember(Value = "input_audio")]
-        InputAudio
+        InputAudio,
+        [EnumMember(Value = "item_reference")]
+        ItemReference
     }
 }

--- a/OpenAI-DotNet/Realtime/RealtimeEndpoint.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeEndpoint.cs
@@ -45,7 +45,7 @@ namespace OpenAI.Realtime
                 session.OnError += OnError;
                 await session.ConnectAsync(cancellationToken).ConfigureAwait(false);
                 var sessionResponse = await sessionCreatedTcs.Task.WithCancellation(cancellationToken).ConfigureAwait(false);
-                session.Options = sessionResponse.Options;
+                session.Configuration = sessionResponse.SessionConfiguration;
                 await session.SendAsync(new UpdateSessionRequest(configuration), cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             finally

--- a/OpenAI-DotNet/Realtime/RealtimeEndpoint.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeEndpoint.cs
@@ -17,12 +17,12 @@ namespace OpenAI.Realtime
         protected override bool? IsWebSocketEndpoint => true;
 
         /// <summary>
-        /// Creates a new realtime session with the provided <see cref="Options"/> options.
+        /// Creates a new realtime session with the provided <see cref="SessionConfiguration"/> options.
         /// </summary>
-        /// <param name="options"><see cref="Options"/>.</param>
+        /// <param name="options"><see cref="SessionConfiguration"/>.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RealtimeSession"/>.</returns>
-        public async Task<RealtimeSession> CreateSessionAsync(Options options = null, CancellationToken cancellationToken = default)
+        public async Task<RealtimeSession> CreateSessionAsync(SessionConfiguration options = null, CancellationToken cancellationToken = default)
         {
             string model = string.IsNullOrWhiteSpace(options?.Model) ? Models.Model.GPT4oRealtime : options!.Model;
             var queryParameters = new Dictionary<string, string>();

--- a/OpenAI-DotNet/Realtime/RealtimeEndpoint.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeEndpoint.cs
@@ -19,12 +19,12 @@ namespace OpenAI.Realtime
         /// <summary>
         /// Creates a new realtime session with the provided <see cref="SessionConfiguration"/> options.
         /// </summary>
-        /// <param name="options"><see cref="SessionConfiguration"/>.</param>
+        /// <param name="configuration"><see cref="SessionConfiguration"/>.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RealtimeSession"/>.</returns>
-        public async Task<RealtimeSession> CreateSessionAsync(SessionConfiguration options = null, CancellationToken cancellationToken = default)
+        public async Task<RealtimeSession> CreateSessionAsync(SessionConfiguration configuration = null, CancellationToken cancellationToken = default)
         {
-            string model = string.IsNullOrWhiteSpace(options?.Model) ? Models.Model.GPT4oRealtime : options!.Model;
+            string model = string.IsNullOrWhiteSpace(configuration?.Model) ? Models.Model.GPT4oRealtime : configuration!.Model;
             var queryParameters = new Dictionary<string, string>();
 
             if (client.OpenAIClientSettings.IsAzureOpenAI)
@@ -46,7 +46,7 @@ namespace OpenAI.Realtime
                 await session.ConnectAsync(cancellationToken).ConfigureAwait(false);
                 var sessionResponse = await sessionCreatedTcs.Task.WithCancellation(cancellationToken).ConfigureAwait(false);
                 session.Options = sessionResponse.Options;
-                await session.SendAsync(new UpdateSessionRequest(options), cancellationToken: cancellationToken).ConfigureAwait(false);
+                await session.SendAsync(new UpdateSessionRequest(configuration), cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/OpenAI-DotNet/Realtime/RealtimeResponseCreateParams.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeResponseCreateParams.cs
@@ -84,6 +84,26 @@ namespace OpenAI.Realtime
             }
         }
 
+        internal RealtimeResponseCreateParams(
+            Modality modalities,
+            string instructions,
+            string voice,
+            RealtimeAudioFormat outputAudioFormat,
+            IReadOnlyList<Function> tools,
+            object toolChoice,
+            float? temperature,
+            object maxResponseOutputTokens)
+        {
+            Modalities = modalities;
+            Instructions = instructions;
+            Voice = voice;
+            OutputAudioFormat = outputAudioFormat;
+            Tools = tools?.ToList();
+            ToolChoice = toolChoice;
+            Temperature = temperature;
+            MaxResponseOutputTokens = maxResponseOutputTokens;
+        }
+
         /// <summary>
         /// The set of modalities the model can respond with. To disable audio, set this to ["text"].
         /// </summary>

--- a/OpenAI-DotNet/Realtime/RealtimeResponseCreateParams.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeResponseCreateParams.cs
@@ -11,6 +11,69 @@ namespace OpenAI.Realtime
     {
         public RealtimeResponseCreateParams() { }
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="modalities">
+        /// The set of modalities the model can respond with. To disable audio, set this to ["text"].
+        /// </param>
+        /// <param name="instructions">
+        /// The default system instructions (i.e. system message) prepended to model
+        /// calls. This field allows the client to guide the model on desired
+        /// responses. The model can be instructed on response content and format,
+        /// (e.g. "be extremely succinct", "act friendly", "here are examples of good
+        /// responses") and on audio behavior (e.g. "talk quickly", "inject emotion
+        /// into your voice", "laugh frequently"). The instructions are not guaranteed
+        /// to be followed by the model, but they provide guidance to the model on the
+        /// desired behavior.<br/>
+        /// Note that the server sets default instructions which will be used if this
+        /// field is not set and are visible in the `session.created` event at the
+        /// start of the session.
+        /// </param>
+        /// <param name="voice">
+        /// The voice the model uses to respond.
+        /// Voice cannot be changed during the session once the model has responded with audio at least once.
+        /// Current voice options are `alloy`, `ash`, `ballad`, `coral`, `echo` `sage`, `shimmer` and `verse`.
+        /// </param>
+        /// <param name="outputAudioFormat">
+        /// The format of output audio. Options are `pcm16`, `g711_ulaw`, or `g711_alaw`.
+        /// </param>
+        /// <param name="tools">
+        /// The description of the function, including guidance on when
+        /// and how to call it, and guidance about what to tell the user when
+        /// calling (if anything).
+        /// </param>
+        /// <param name="toolChoice">
+        /// How the model chooses tools. Options are `auto`, `none`, `required`, or 
+        /// specify a function, like `{"type": "function", "function": {"name": "my_function"}}`.
+        /// </param>
+        /// <param name="temperature">
+        /// Sampling temperature for the model, limited to [0.6, 1.2]. Defaults to 0.8.
+        /// </param>
+        /// <param name="maxResponseOutputTokens">
+        /// Maximum number of output tokens for a single assistant response,
+        /// inclusive of tool calls. Provide an integer between 1 and 4096 to
+        /// limit output tokens, or `inf` for the maximum available tokens for a
+        /// given model. Defaults to `inf`.
+        /// </param>
+        /// <param name="conversation">
+        /// Controls which conversation the response is added to. Currently, supports
+        /// `auto` and `none`, with `auto` as the default value. The `auto` value
+        /// means that the contents of the response will be added to the default
+        /// conversation. Set this to `none` to create an out-of-band response which
+        /// will not add items to default conversation.
+        /// </param>
+        /// <param name="metadata">
+        /// Set of 16 key-value pairs that can be attached to an object.
+        /// This can be useful for storing additional information about the object in a structured format.
+        /// Keys can be a maximum of 64 characters long and values can be a maximum of 512 characters long.
+        /// </param>
+        /// <param name="input">
+        /// Input items to include in the prompt for the model. Using this field
+        /// creates a new context for this Response instead of using the default
+        /// conversation. An empty array `[]` will clear the context for this Response.<br/>
+        /// Note that this can include references to items from the default conversation.
+        /// </param>
         public RealtimeResponseCreateParams(
             Modality modalities = Modality.Text | Modality.Audio,
             string instructions = null,
@@ -20,11 +83,12 @@ namespace OpenAI.Realtime
             string toolChoice = null,
             float? temperature = null,
             int? maxResponseOutputTokens = null,
+            ConversationResponseType conversation = ConversationResponseType.Auto,
             IReadOnlyDictionary<string, string> metadata = null,
             object[] input = null)
         {
             Modalities = modalities;
-            Voice = voice ?? null;
+            Voice = voice;
             Instructions = string.IsNullOrWhiteSpace(instructions)
                 ? "Your knowledge cutoff is 2023-10. You are a helpful, witty, and friendly AI. Act like a human, " +
                   "but remember that you aren't a human and that you can't do human things in the real world. " +
@@ -82,6 +146,10 @@ namespace OpenAI.Realtime
                     _ => maxResponseOutputTokens
                 };
             }
+
+            Conversation = conversation;
+            Metadata = metadata;
+            Input = input;
         }
 
         internal RealtimeResponseCreateParams(
@@ -89,7 +157,7 @@ namespace OpenAI.Realtime
             string instructions,
             string voice,
             RealtimeAudioFormat outputAudioFormat,
-            IReadOnlyList<Function> tools,
+            IEnumerable<Function> tools,
             object toolChoice,
             float? temperature,
             object maxResponseOutputTokens)
@@ -132,13 +200,18 @@ namespace OpenAI.Realtime
         public string Instructions { get; private set; }
 
         /// <summary>
-        /// The format of output audio. Options are `pcm16`, `g711_ulaw`, or `g711_alaw`.
+        /// The voice the model uses to respond.
+        /// Voice cannot be changed during the session once the model has responded with audio at least once.
+        /// Current voice options are `alloy`, `ash`, `ballad`, `coral`, `echo` `sage`, `shimmer` and `verse`.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("voice")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Voice { get; private set; }
 
+        /// <summary>
+        /// The format of output audio. Options are `pcm16`, `g711_ulaw`, or `g711_alaw`.
+        /// </summary>
         [JsonInclude]
         [JsonPropertyName("output_audio_format")]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
@@ -182,6 +255,18 @@ namespace OpenAI.Realtime
         public object MaxResponseOutputTokens { get; private set; }
 
         /// <summary>
+        /// Controls which conversation the response is added to. Currently, supports
+        /// `auto` and `none`, with `auto` as the default value. The `auto` value
+        /// means that the contents of the response will be added to the default
+        /// conversation. Set this to `none` to create an out-of-band response which
+        /// will not add items to default conversation.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("conversation")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public ConversationResponseType Conversation { get; private set; }
+
+        /// <summary>
         /// Set of 16 key-value pairs that can be attached to an object.
         /// This can be useful for storing additional information about the object in a structured format.
         /// Keys can be a maximum of 64 characters long and values can be a maximum of 512 characters long.
@@ -198,6 +283,7 @@ namespace OpenAI.Realtime
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("input")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
         public object[] Input { get; private set; }
     }
 }

--- a/OpenAI-DotNet/Realtime/RealtimeResponseCreateParams.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeResponseCreateParams.cs
@@ -7,6 +7,9 @@ using System.Text.Json.Serialization;
 
 namespace OpenAI.Realtime
 {
+    /// <summary>
+    /// Create a new Realtime response with these parameters.
+    /// </summary>
     public sealed class RealtimeResponseCreateParams
     {
         public RealtimeResponseCreateParams() { }
@@ -85,7 +88,7 @@ namespace OpenAI.Realtime
             int? maxResponseOutputTokens = null,
             ConversationResponseType conversation = ConversationResponseType.Auto,
             IReadOnlyDictionary<string, string> metadata = null,
-            object[] input = null)
+            IEnumerable<ConversationItem> input = null)
         {
             Modalities = modalities;
             Voice = voice;
@@ -149,7 +152,16 @@ namespace OpenAI.Realtime
 
             Conversation = conversation;
             Metadata = metadata;
-            Input = input;
+
+            if (input != null)
+            {
+                Input = input.ToList();
+
+                foreach (var item in Input)
+                {
+                    item.Type = ConversationItemType.ItemReference;
+                }
+            }
         }
 
         internal RealtimeResponseCreateParams(
@@ -284,6 +296,6 @@ namespace OpenAI.Realtime
         [JsonInclude]
         [JsonPropertyName("input")]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-        public object[] Input { get; private set; }
+        public IReadOnlyList<ConversationItem> Input { get; private set; }
     }
 }

--- a/OpenAI-DotNet/Realtime/RealtimeResponseResource.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeResponseResource.cs
@@ -47,6 +47,10 @@ namespace OpenAI.Realtime
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public IReadOnlyList<ConversationItem> Output { get; private set; }
 
+        [JsonInclude]
+        [JsonPropertyName("metadata")]
+        public IReadOnlyDictionary<string, object> Metadata { get; private set; }
+
         /// <summary>
         /// Usage statistics for the Response, this will correspond to billing.
         /// A Realtime API session will maintain a conversation context and append new Items to the Conversation,
@@ -56,5 +60,59 @@ namespace OpenAI.Realtime
         [JsonPropertyName("usage")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public Usage Usage { get; private set; }
+
+        /// <summary>
+        /// Which conversation the response is added to, determined by the `conversation`
+        /// field in the `response.create` event. If `auto`, the response will be added to
+        /// the default conversation and the value of `conversation_id` will be an id like
+        /// `conv_1234`. If `none`, the response will not be added to any conversation and
+        /// the value of `conversation_id` will be `null`. If responses are being triggered
+        /// by server VAD, the response will be added to the default conversation, thus
+        /// the `conversation_id` will be an id like `conv_1234`.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("conversation_id")]
+        public string ConversationId { get; private set; }
+
+        /// <summary>
+        /// The voice the model used to respond.
+        /// Current voice options are `alloy`, `ash`, `ballad`, `coral`, `echo` `sage`, `shimmer` and `verse`.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("voice")]
+        public string Voice { get; private set; }
+
+        /// <summary>
+        /// The set of modalities the model used to respond. If there are multiple modalities,
+        /// the model will pick one, for example if `modalities` is `["text", "audio"]`, the model
+        /// could be responding in either text or audio.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("modalities")]
+        [JsonConverter(typeof(ModalityConverter))]
+        public Modality Modalities { get; private set; }
+
+        /// <summary>
+        /// The format of output audio. Options are `pcm16`, `g711_ulaw`, or `g711_alaw`.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("output_audio_format")]
+        [JsonConverter(typeof(Extensions.JsonStringEnumConverter<RealtimeAudioFormat>))]
+        public RealtimeAudioFormat OutputAudioFormat { get; private set; }
+
+        /// <summary>
+        /// Sampling temperature for the model, limited to [0.6, 1.2]. Defaults to 0.8.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("temperature")]
+        public float Temperature { get; private set; }
+
+        /// <summary>
+        ///  Maximum number of output tokens for a single assistant response, inclusive of tool calls, that was used in this response.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("max_output_tokens")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public object MaxOutputTokens { get; private set; }
     }
 }

--- a/OpenAI-DotNet/Realtime/RealtimeResponseResource.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeResponseResource.cs
@@ -47,6 +47,13 @@ namespace OpenAI.Realtime
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public IReadOnlyList<ConversationItem> Output { get; private set; }
 
+        /// <summary>
+        /// Set of 16 key-value pairs that can be attached to an object.
+        /// This can be useful for storing additional information about the object in a structured format,
+        /// and querying for objects via API or the dashboard.
+        /// Keys are strings with a maximum length of 64 characters.
+        /// Values are strings with a maximum length of 512 characters.
+        /// </summary>
         [JsonInclude]
         [JsonPropertyName("metadata")]
         public IReadOnlyDictionary<string, object> Metadata { get; private set; }

--- a/OpenAI-DotNet/Realtime/RealtimeSession.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeSession.cs
@@ -23,7 +23,7 @@ namespace OpenAI.Realtime
         /// </summary>
         public int EventTimeout { get; set; } = 30;
 
-        [Obsolete("Use Configuration")]
+        [Obsolete("Use RealtimeSession.Configuration")]
         public SessionConfiguration Options => Configuration;
 
         /// <summary>

--- a/OpenAI-DotNet/Realtime/RealtimeSession.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeSession.cs
@@ -144,7 +144,7 @@ namespace OpenAI.Realtime
         /// <param name="sessionEvent">The event to receive updates for.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="Task"/>.</returns>
-        /// <exception cref="Exception">If <see cref="ReceiveUpdatesAsync{T}"/> is already running.</exception>
+        /// <exception cref="Exception">If <see cref="ReceiveUpdatesAsync{T}(CancellationToken)"/> is already running.</exception>
         public async Task ReceiveUpdatesAsync<T>(Action<T> sessionEvent, CancellationToken cancellationToken) where T : IRealtimeEvent
         {
             try
@@ -202,7 +202,7 @@ namespace OpenAI.Realtime
         /// <typeparam name="T"><see cref="IRealtimeEvent"/> to subscribe for updates to.</typeparam>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="IAsyncEnumerable{T}"/>.</returns>
-        /// <exception cref="Exception">If <see cref="ReceiveUpdatesAsync{T}"/> is already running.</exception>
+        /// <exception cref="Exception">If <see cref="ReceiveUpdatesAsync{T}(CancellationToken)"/> is already running.</exception>
         public async IAsyncEnumerable<T> ReceiveUpdatesAsync<T>([EnumeratorCancellation] CancellationToken cancellationToken) where T : IRealtimeEvent
         {
             try
@@ -260,7 +260,7 @@ namespace OpenAI.Realtime
         /// </summary>
         /// <typeparam name="T"><see cref="IClientEvent"/> to send to the server.</typeparam>
         /// <param name="event">The event to send.</param>
-        /// <param name="sessionEvents">Optional, <see cref="Action{IServerEvent}"/>.</param>
+        /// <param name="@event">Optional, <see cref="Action{IServerEvent}"/>.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="Task{IServerEvent}"/>.</returns>
         public async Task<IServerEvent> SendAsync<T>(T @event, CancellationToken cancellationToken = default) where T : IClientEvent

--- a/OpenAI-DotNet/Realtime/RealtimeSession.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeSession.cs
@@ -23,10 +23,13 @@ namespace OpenAI.Realtime
         /// </summary>
         public int EventTimeout { get; set; } = 30;
 
+        [Obsolete("Use Configuration")]
+        public SessionConfiguration Options => Configuration;
+
         /// <summary>
         /// The configuration options for the session.
         /// </summary>
-        public SessionConfiguration Options { get; internal set; }
+        public SessionConfiguration Configuration { get; internal set; }
 
         #region Internal
 
@@ -351,7 +354,7 @@ namespace OpenAI.Realtime
                     switch (clientEvent)
                     {
                         case UpdateSessionRequest when serverEvent is SessionResponse sessionResponse:
-                            Options = sessionResponse.Options;
+                            Configuration = sessionResponse.SessionConfiguration;
                             Complete();
                             return;
                         case InputAudioBufferCommitRequest when serverEvent is InputAudioBufferCommittedResponse:

--- a/OpenAI-DotNet/Realtime/RealtimeSession.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeSession.cs
@@ -24,9 +24,9 @@ namespace OpenAI.Realtime
         public int EventTimeout { get; set; } = 30;
 
         /// <summary>
-        /// The options for the session.
+        /// The configuration options for the session.
         /// </summary>
-        public Options Options { get; internal set; }
+        public SessionConfiguration Options { get; internal set; }
 
         #region Internal
 
@@ -362,23 +362,23 @@ namespace OpenAI.Realtime
                             Complete();
                             return;
                         case CreateResponseRequest when serverEvent is RealtimeResponse serverResponse:
+                        {
+                            if (serverResponse.Response.Status == RealtimeResponseStatus.InProgress)
                             {
-                                if (serverResponse.Response.Status == RealtimeResponseStatus.InProgress)
-                                {
-                                    return;
-                                }
-
-                                if (serverResponse.Response.Status != RealtimeResponseStatus.Completed)
-                                {
-                                    tcs.TrySetException(new Exception(serverResponse.Response.StatusDetails.Error?.ToString() ?? serverResponse.Response.StatusDetails.Reason));
-                                }
-                                else
-                                {
-                                    Complete();
-                                }
-
-                                break;
+                                return;
                             }
+
+                            if (serverResponse.Response.Status != RealtimeResponseStatus.Completed)
+                            {
+                                tcs.TrySetException(new Exception(serverResponse.Response.StatusDetails.Error?.ToString() ?? serverResponse.Response.StatusDetails.Reason));
+                            }
+                            else
+                            {
+                                Complete();
+                            }
+
+                            break;
+                        }
                     }
                 }
                 catch (Exception e)

--- a/OpenAI-DotNet/Realtime/ResponseCancelRequest.cs
+++ b/OpenAI-DotNet/Realtime/ResponseCancelRequest.cs
@@ -10,6 +10,22 @@ namespace OpenAI.Realtime
     /// </summary>
     public sealed class ResponseCancelRequest : BaseRealtimeEvent, IClientEvent
     {
+        /// <summary>
+        /// Default Constructor.
+        /// </summary>
+        public ResponseCancelRequest() { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="responseId">
+        /// A specific response ID to cancel - if not provided, will cancel an in-progress response in the default conversation.
+        /// </param>
+        public ResponseCancelRequest(string responseId)
+        {
+            ResponseId = responseId;
+        }
+
         /// <inheritdoc />
         [JsonInclude]
         [JsonPropertyName("event_id")]
@@ -19,5 +35,12 @@ namespace OpenAI.Realtime
         [JsonInclude]
         [JsonPropertyName("type")]
         public override string Type { get; protected set; } = "response.cancel";
+
+        /// <summary>
+        /// A specific response ID to cancel - if not provided, will cancel an in-progress response in the default conversation.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("response_id")]
+        public string ResponseId { get; private set; }
     }
 }

--- a/OpenAI-DotNet/Realtime/SessionConfiguration.cs
+++ b/OpenAI-DotNet/Realtime/SessionConfiguration.cs
@@ -161,6 +161,7 @@ namespace OpenAI.Realtime
 
         [JsonInclude]
         [JsonPropertyName("turn_detection")]
+        [JsonConverter(typeof(VoiceActivityDetectionSettingsConverter))]
         public VoiceActivityDetectionSettings VoiceActivityDetectionSettings { get; private set; }
 
         [JsonInclude]

--- a/OpenAI-DotNet/Realtime/SessionConfiguration.cs
+++ b/OpenAI-DotNet/Realtime/SessionConfiguration.cs
@@ -8,27 +8,11 @@ using System.Text.Json.Serialization;
 
 namespace OpenAI.Realtime
 {
-    [Obsolete("use SessionConfiguration")]
-    public sealed class Options
+    public class SessionConfiguration
     {
-        public static implicit operator SessionConfiguration(Options options)
-            => new(
-                options.Model,
-                options.Modalities,
-                options.Voice,
-                options.Instructions,
-                options.InputAudioFormat,
-                options.OutputAudioFormat,
-                options.InputAudioTranscriptionSettings,
-                options.VoiceActivityDetectionSettings,
-                options.Tools,
-                options.ToolChoice,
-                options.Temperature,
-                options.MaxResponseOutputTokens);
+        public SessionConfiguration() { }
 
-        public Options() { }
-
-        public Options(
+        public SessionConfiguration(
             Model model,
             Modality modalities = Modality.Text | Modality.Audio,
             Voice voice = null,
@@ -111,31 +95,33 @@ namespace OpenAI.Realtime
             }
         }
 
-        [JsonInclude]
-        [JsonPropertyName("id")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public string Id { get; private set; }
-
-        [JsonInclude]
-        [JsonPropertyName("object")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public string Object { get; private set; }
-
-        [JsonInclude]
-        [JsonPropertyName("model")]
-        public string Model { get; private set; }
-
-        [JsonInclude]
-        [JsonPropertyName("expires_at")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public int? ExpiresAtTimeUnixSeconds { get; private set; }
-
-        [JsonInclude]
-        [JsonIgnore]
-        public DateTime? ExpiresAt =>
-            ExpiresAtTimeUnixSeconds.HasValue
-                ? DateTimeOffset.FromUnixTimeSeconds(ExpiresAtTimeUnixSeconds.Value).DateTime
-                : null;
+        internal SessionConfiguration(
+            string model,
+            Modality modalities,
+            string voice,
+            string instructions,
+            RealtimeAudioFormat inputAudioFormat,
+            RealtimeAudioFormat outputAudioFormat,
+            InputAudioTranscriptionSettings inputAudioTranscriptionSettings,
+            VoiceActivityDetectionSettings voiceActivityDetectionSettings,
+            IReadOnlyList<Function> tools,
+            object toolChoice,
+            float? temperature,
+            object maxResponseOutputTokens)
+        {
+            Model = model;
+            Modalities = modalities;
+            Voice = voice;
+            Instructions = instructions;
+            InputAudioFormat = inputAudioFormat;
+            OutputAudioFormat = outputAudioFormat;
+            InputAudioTranscriptionSettings = inputAudioTranscriptionSettings;
+            VoiceActivityDetectionSettings = voiceActivityDetectionSettings;
+            Tools = tools;
+            ToolChoice = toolChoice;
+            Temperature = temperature;
+            MaxResponseOutputTokens = maxResponseOutputTokens;
+        }
 
         [JsonInclude]
         [JsonPropertyName("modalities")]
@@ -144,14 +130,18 @@ namespace OpenAI.Realtime
         public Modality Modalities { get; private set; }
 
         [JsonInclude]
-        [JsonPropertyName("voice")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public string Voice { get; private set; }
+        [JsonPropertyName("model")]
+        public string Model { get; private set; }
 
         [JsonInclude]
         [JsonPropertyName("instructions")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Instructions { get; private set; }
+
+        [JsonInclude]
+        [JsonPropertyName("voice")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string Voice { get; private set; }
 
         [JsonInclude]
         [JsonPropertyName("input_audio_format")]

--- a/OpenAI-DotNet/Realtime/SessionResponse.cs
+++ b/OpenAI-DotNet/Realtime/SessionResponse.cs
@@ -25,7 +25,7 @@ namespace OpenAI.Realtime
         public SessionConfiguration SessionConfiguration { get; private set; }
 
         [JsonIgnore]
-        [Obsolete("use SessionConfiguration")]
+        [Obsolete("use SessionResponse.SessionConfiguration")]
         public SessionConfiguration Options => SessionConfiguration;
     }
 }

--- a/OpenAI-DotNet/Realtime/SessionResponse.cs
+++ b/OpenAI-DotNet/Realtime/SessionResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Text.Json.Serialization;
 
 namespace OpenAI.Realtime
@@ -17,10 +18,14 @@ namespace OpenAI.Realtime
         public override string Type { get; protected set; }
 
         /// <summary>
-        /// The session resource options.
+        /// The session resource configuration.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("session")]
-        public SessionConfiguration Options { get; private set; }
+        public SessionConfiguration SessionConfiguration { get; private set; }
+
+        [JsonIgnore]
+        [Obsolete("use SessionConfiguration")]
+        public SessionConfiguration Options => SessionConfiguration;
     }
 }

--- a/OpenAI-DotNet/Realtime/SessionResponse.cs
+++ b/OpenAI-DotNet/Realtime/SessionResponse.cs
@@ -21,6 +21,6 @@ namespace OpenAI.Realtime
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("session")]
-        public Options Options { get; private set; }
+        public SessionConfiguration Options { get; private set; }
     }
 }

--- a/OpenAI-DotNet/Realtime/StatusDetails.cs
+++ b/OpenAI-DotNet/Realtime/StatusDetails.cs
@@ -11,7 +11,8 @@ namespace OpenAI.Realtime
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("type")]
-        public string Type { get; private set; }
+        [JsonConverter(typeof(Extensions.JsonStringEnumConverter<RealtimeResponseStatus>))]
+        public RealtimeResponseStatus Type { get; private set; }
 
         /// <summary>
         /// The reason the Response did not complete.

--- a/OpenAI-DotNet/Realtime/UpdateSessionRequest.cs
+++ b/OpenAI-DotNet/Realtime/UpdateSessionRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Text.Json.Serialization;
 
 namespace OpenAI.Realtime
@@ -15,9 +16,9 @@ namespace OpenAI.Realtime
     {
         public UpdateSessionRequest() { }
 
-        public UpdateSessionRequest(Options options)
+        public UpdateSessionRequest(SessionConfiguration options)
         {
-            Session = options;
+            Options = options;
         }
 
         /// <inheritdoc />
@@ -31,10 +32,14 @@ namespace OpenAI.Realtime
         public override string Type { get; protected set; } = "session.update";
 
         /// <summary>
-        /// The session resource.
+        /// The session configuration options.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("session")]
-        public Options Session { get; private set; }
+        public SessionConfiguration Options { get; private set; }
+
+        [JsonIgnore]
+        [Obsolete("use UpdateSessionRequest.Options")]
+        public SessionConfiguration Session => Options;
     }
 }

--- a/OpenAI-DotNet/Realtime/UpdateSessionRequest.cs
+++ b/OpenAI-DotNet/Realtime/UpdateSessionRequest.cs
@@ -16,9 +16,9 @@ namespace OpenAI.Realtime
     {
         public UpdateSessionRequest() { }
 
-        public UpdateSessionRequest(SessionConfiguration options)
+        public UpdateSessionRequest(SessionConfiguration configuration)
         {
-            Options = options;
+            Configuration = configuration;
         }
 
         /// <inheritdoc />
@@ -36,10 +36,10 @@ namespace OpenAI.Realtime
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("session")]
-        public SessionConfiguration Options { get; private set; }
+        public SessionConfiguration Configuration { get; private set; }
 
         [JsonIgnore]
-        [Obsolete("use UpdateSessionRequest.Options")]
-        public SessionConfiguration Session => Options;
+        [Obsolete("use UpdateSessionRequest.Configuration")]
+        public SessionConfiguration Session => Configuration;
     }
 }

--- a/OpenAI-DotNet/Realtime/VoiceActivityDetectionSettings.cs
+++ b/OpenAI-DotNet/Realtime/VoiceActivityDetectionSettings.cs
@@ -12,7 +12,8 @@ namespace OpenAI.Realtime
             TurnDetectionType type = TurnDetectionType.Server_VAD,
             float? detectionThreshold = null,
             int? prefixPadding = null,
-            int? silenceDuration = null)
+            int? silenceDuration = null,
+            bool createResponse = true)
         {
             switch (type)
             {
@@ -21,6 +22,14 @@ namespace OpenAI.Realtime
                     DetectionThreshold = detectionThreshold;
                     PrefixPadding = prefixPadding;
                     SilenceDuration = silenceDuration;
+                    CreateResponse = createResponse;
+                    break;
+                case TurnDetectionType.Disabled:
+                    Type = TurnDetectionType.Disabled;
+                    DetectionThreshold = null;
+                    PrefixPadding = null;
+                    SilenceDuration = null;
+                    CreateResponse = false;
                     break;
             }
         }
@@ -33,18 +42,23 @@ namespace OpenAI.Realtime
 
         [JsonInclude]
         [JsonPropertyName("threshold")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public float? DetectionThreshold { get; private set; }
 
         [JsonInclude]
         [JsonPropertyName("prefix_padding_ms")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public int? PrefixPadding { get; private set; }
 
         [JsonInclude]
         [JsonPropertyName("silence_duration_ms")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public int? SilenceDuration { get; private set; }
+
+        [JsonInclude]
+        [JsonPropertyName("create_response")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool CreateResponse { get; private set; }
 
         public static VoiceActivityDetectionSettings Disabled() => new(TurnDetectionType.Disabled);
     }

--- a/OpenAI-DotNet/Realtime/VoiceActivityDetectionSettings.cs
+++ b/OpenAI-DotNet/Realtime/VoiceActivityDetectionSettings.cs
@@ -17,6 +17,7 @@ namespace OpenAI.Realtime
         {
             switch (type)
             {
+                default:
                 case TurnDetectionType.Server_VAD:
                     Type = TurnDetectionType.Server_VAD;
                     DetectionThreshold = detectionThreshold;

--- a/README.md
+++ b/README.md
@@ -435,8 +435,8 @@ var tools = new List<Tool>
         return "Goodbye!";
     })
 };
-var options = new Options(Model.GPT4oRealtime, tools: tools);
-using var session = await api.RealtimeEndpoint.CreateSessionAsync(options);
+var configuration = new SessionConfiguration(Model.GPT4oRealtime, tools: tools);
+using var session = await api.RealtimeEndpoint.CreateSessionAsync(configuration);
 var responseTask = session.ReceiveUpdatesAsync<IServerEvent>(ServerEvents, cancellationTokenSource.Token);
 await session.SendAsync(new ConversationItemCreateRequest("Hello!"));
 await session.SendAsync(new CreateResponseRequest());
@@ -769,7 +769,8 @@ Console.WriteLine($"Retrieve thread {thread.Id} -> {thread.CreatedAt}");
 
 Modifies a thread.
 
-> Note: Only the metadata can be modified.
+> [!NOTE]
+> Only the metadata can be modified.
 
 ```csharp
 using var api = new OpenAIClient();
@@ -847,7 +848,8 @@ Console.WriteLine($"{message.Id}: {message.Role}: {message.PrintContent()}");
 
 Modify a message.
 
-> Note: Only the message metadata can be modified.
+> [!NOTE]
+> Only the metadata can be modified.
 
 ```csharp
 using var api = new OpenAIClient();
@@ -942,7 +944,8 @@ Console.WriteLine($"[{run.Id}] {run.Status} | {run.CreatedAt}");
 
 Modifies a run.
 
-> Note: Only the metadata can be modified.
+> [!NOTE]
+> Only the metadata can be modified.
 
 ```csharp
 using var api = new OpenAIClient();


### PR DESCRIPTION
- Deprecated OpenAI.Realtime.Options
- Added OpenAI.Realtime.SessionConfiguration to specify the options of the RealtimeSession when creating a new session
- Added OpenAI.Realtime.RealtimeResponseCreateParams to specify the options of the CreateResponseRequest
- Added VoiceActivityDetectionSettingsConverter to better handle disabled voice activity detection
- Added VoiceActivityDetectionSettings.CreateResponse property