### PR TITLE
OpenAI-DotNet 8.6.1

### DIFF
--- a/OpenAI-DotNet/Models/Model.cs
+++ b/OpenAI-DotNet/Models/Model.cs
@@ -73,6 +73,8 @@ namespace OpenAI.Models
         [JsonPropertyName("parent")]
         public string Parent { get; private set; }
 
+        public static Model GPT4_5 { get; } = new("gpt-4.5-preview", "openai");
+
         public static Model O1 { get; } = new("o1-preview", "openai");
 
         public static Model O1Mini { get; } = new("o1-mini", "openai");
@@ -169,11 +171,12 @@ namespace OpenAI.Models
         /// </remarks>
         public static Model Embedding_3_Large { get; } = new("text-embedding-3-large", "openai");
 
-        /// <summary>
-        /// The default model for <see cref="Moderations.ModerationsEndpoint"/>.
-        /// </summary>
+        public static Model OmniModerationLatest { get; } = new("omni-moderation-latest", "openai");
+
+        [Obsolete("use OmniModerationLatest")]
         public static Model Moderation_Latest { get; } = new("text-moderation-latest", "openai");
 
+        [Obsolete("Removed")]
         public static Model Moderation_Stable { get; } = new("text-moderation-stable", "openai");
 
         /// <summary>

--- a/OpenAI-DotNet/Moderations/ModerationsRequest.cs
+++ b/OpenAI-DotNet/Moderations/ModerationsRequest.cs
@@ -24,7 +24,7 @@ namespace OpenAI.Moderations
         public ModerationsRequest(string input, string model = null)
         {
             Input = input;
-            Model = string.IsNullOrWhiteSpace(model) ? Models.Model.Moderation_Latest : model;
+            Model = string.IsNullOrWhiteSpace(model) ? Models.Model.OmniModerationLatest : model;
         }
 
         [JsonPropertyName("input")]

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -29,8 +29,15 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>8.6.0</Version>
+    <Version>8.6.1</Version>
     <PackageReleaseNotes>
+Version 8.6.1
+- Updated Models list
+  - Added gpt-4.5
+  - Updated moderation models
+    - removed text-moderation-stable
+    - added omni-moderation-latest
+    - deprecated text-moderation-latest, use omni-moderation-latest
 Version 8.6.0
 - Deprecated OpenAI.Realtime.Options
 - Added OpenAI.Realtime.SessionConfiguration to specify the options of the RealtimeSession when creating a new session


### PR DESCRIPTION
- updated Hardcoded Models
  - added [gpt-4.5](https://openai.com/index/introducing-gpt-4-5/)
  - updated moderation models
    - removed text-moderation-stable
    - added omni-moderation-latest
    - deprecated text-moderation-latest, use omni-moderation-latest