### PR TITLE
OpenAI-DotNet 8.7.4

### DIFF
--- a/OpenAI-DotNet-Proxy/OpenAI-DotNet-Proxy.csproj
+++ b/OpenAI-DotNet-Proxy/OpenAI-DotNet-Proxy.csproj
@@ -22,8 +22,11 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SignAssembly>false</SignAssembly>
     <ImplicitUsings>false</ImplicitUsings>
-    <Version>8.7.0</Version>
+    <Version>8.7.4</Version>
     <PackageReleaseNotes>
+Version 8.7.4
+- Updated proxy support for the OpenAI-DotNet package
+- Ensure we're returning the full response message body and content length to the clients
 Version 8.7.0
 - Fix Azure OpenAI api-version query parameter not being forwarded correctly
 Version 8.4.0

--- a/OpenAI-DotNet-Proxy/Readme.md
+++ b/OpenAI-DotNet-Proxy/Readme.md
@@ -75,7 +75,7 @@ public partial class Program
 
     public static void Main(string[] args)
     {
-        var auth = OpenAIAuthentication.LoadFromEnv();
+        var auth = OpenAIAuthentication.LoadFromEnvironment();
         var settings = new OpenAISettings(/* your custom settings if using Azure OpenAI */);
         using var openAIClient = new OpenAIClient(auth, settings);
         OpenAIProxy.CreateWebApplication<AuthenticationFilter>(args, openAIClient).Run();

--- a/OpenAI-DotNet-Tests-Proxy/Program.cs
+++ b/OpenAI-DotNet-Tests-Proxy/Program.cs
@@ -33,7 +33,7 @@ namespace OpenAI.Tests.Proxy
 
         public static void Main(string[] args)
         {
-            var auth = OpenAIAuthentication.LoadFromEnv();
+            var auth = OpenAIAuthentication.LoadFromEnvironment();
             var settings = new OpenAISettings(/* your custom settings if using Azure OpenAI */);
             using var openAIClient = new OpenAIClient(auth, settings);
             using var app = OpenAIProxy.CreateWebApplication<AuthenticationFilter>(args, openAIClient);

--- a/OpenAI-DotNet-Tests/TestFixture_00_01_Authentication.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_00_01_Authentication.cs
@@ -22,12 +22,12 @@ namespace OpenAI.Tests
         [Test]
         public void Test_01_GetAuthFromEnv()
         {
-            var auth = OpenAIAuthentication.LoadFromEnv();
+            var auth = OpenAIAuthentication.LoadFromEnvironment();
             Assert.IsNotNull(auth);
             Assert.IsNotNull(auth.ApiKey);
             Assert.IsNotEmpty(auth.ApiKey);
 
-            auth = OpenAIAuthentication.LoadFromEnv("org-testOrg");
+            auth = OpenAIAuthentication.LoadFromEnvironment("org-testOrg");
             Assert.IsNotNull(auth);
             Assert.IsNotNull(auth.ApiKey);
             Assert.IsNotEmpty(auth.ApiKey);

--- a/OpenAI-DotNet/Authentication/OpenAIAuthentication.cs
+++ b/OpenAI-DotNet/Authentication/OpenAIAuthentication.cs
@@ -71,7 +71,7 @@ namespace OpenAI
         /// <summary>
         /// The default authentication to use when no other auth is specified.
         /// This can be set manually, or automatically loaded via environment variables or a config file.
-        /// <seealso cref="LoadFromEnv"/><seealso cref="LoadFromDirectory"/>
+        /// <seealso cref="LoadFromEnvironment"/><seealso cref="LoadFromDirectory"/>
         /// </summary>
         public static OpenAIAuthentication Default
         {
@@ -84,12 +84,16 @@ namespace OpenAI
 
                 var auth = LoadFromDirectory() ??
                            LoadFromDirectory(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)) ??
-                           LoadFromEnv();
+                           LoadFromEnvironment();
                 cachedDefault = auth ?? throw new UnauthorizedAccessException("Failed to load a valid API Key!");
                 return auth;
             }
             internal set => cachedDefault = value;
         }
+
+        [Obsolete("use LoadFromEnvironment")]
+        public static OpenAIAuthentication LoadFromEnv(string organizationId = null)
+            => LoadFromEnvironment(organizationId);
 
         /// <summary>
         /// Attempts to load api keys from environment variables, as "OPENAI_KEY" (or "OPENAI_SECRET_KEY", for backwards compatibility)
@@ -102,7 +106,7 @@ namespace OpenAI
         /// Returns the loaded <see cref="OpenAIAuthentication"/> any api keys were found,
         /// or <see langword="null"/> if there were no matching environment vars.
         /// </returns>
-        public static OpenAIAuthentication LoadFromEnv(string organizationId = null)
+        public static OpenAIAuthentication LoadFromEnvironment(string organizationId = null)
         {
             var apiKey = Environment.GetEnvironmentVariable(OPENAI_KEY);
 

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -29,8 +29,11 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>8.7.3</Version>
+    <Version>8.7.4</Version>
     <PackageReleaseNotes>
+Version 8.7.4
+- Updated proxy support for the OpenAI-DotNet-Proxy package
+- Renamed OpenAIAuthentication.LoadFromEnv -&gt; OpenAIAuthentication.LoadFromEnvironment
 Version 8.7.3
 - Fixed Response.Instructions deserialization when using CreateResponseRequest.Prompt
 Version 8.7.2
@@ -481,7 +484,8 @@ Version 4.4.0
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub"
+      Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Use your system's environment variables specify an api key and organization to u
 - Use `OPENAI_PROJECT_ID` to specify a project.
 
 ```csharp
-using var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
+using var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnvironment());
 ```
 
 ### Handling OpenAIClient and HttpClient Lifecycle
@@ -355,7 +355,7 @@ public partial class Program
 
     public static void Main(string[] args)
     {
-        var auth = OpenAIAuthentication.LoadFromEnv();
+        var auth = OpenAIAuthentication.LoadFromEnvironment();
         var settings = new OpenAISettings(/* your custom settings if using Azure OpenAI */);
         using var openAIClient = new OpenAIClient(auth, settings);
         OpenAIProxy.CreateWebApplication<AuthenticationFilter>(args, openAIClient).Run();


### PR DESCRIPTION
- Updated proxy support for the OpenAI-DotNet-Proxy package
- Renamed OpenAIAuthentication.LoadFromEnv -> OpenAIAuthentication.LoadFromEnvironment

## OpenAI-DotNet-Proxy 8.7.4
- Updated proxy support for the OpenAI-DotNet package
- Ensure we're returning the full response message body and content length to the clients