### PR TITLE
OpenAI-DotNet 8.8.0

### DIFF
--- a/OpenAI-DotNet-Proxy/OpenAI-DotNet-Proxy.csproj
+++ b/OpenAI-DotNet-Proxy/OpenAI-DotNet-Proxy.csproj
@@ -22,8 +22,10 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SignAssembly>false</SignAssembly>
     <ImplicitUsings>false</ImplicitUsings>
-    <Version>8.7.4</Version>
+    <Version>8.8.0</Version>
     <PackageReleaseNotes>
+Version 8.8.0
+- Removed Websocket handling from the proxy
 Version 8.7.4
 - Updated proxy support for the OpenAI-DotNet package
 - Ensure we're returning the full response message body and content length to the clients

--- a/OpenAI-DotNet-Proxy/Proxy/OpenAIProxy.cs
+++ b/OpenAI-DotNet-Proxy/Proxy/OpenAIProxy.cs
@@ -42,7 +42,6 @@ namespace OpenAI.Proxy
             SetupServices(app.ApplicationServices);
 
             app.UseHttpsRedirection();
-            app.UseWebSockets();
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
@@ -82,7 +81,8 @@ namespace OpenAI.Proxy
         /// <typeparam name="T"><see cref="IAuthenticationFilter"/> type to use to validate your custom issued tokens.</typeparam>
         /// <param name="args">Startup args.</param>
         /// <param name="openAIClient"><see cref="OpenAIClient"/> with configured <see cref="OpenAIAuthentication"/> and <see cref="OpenAISettings"/>.</param>
-        public static WebApplication CreateWebApplication<T>(string[] args, OpenAIClient openAIClient) where T : class, IAuthenticationFilter
+        /// <param name="routePrefix"></param>
+        public static WebApplication CreateWebApplication<T>(string[] args, OpenAIClient openAIClient, string routePrefix = "") where T : class, IAuthenticationFilter
         {
             var builder = WebApplication.CreateBuilder(args);
             builder.Logging.ClearProviders();

--- a/OpenAI-DotNet-Tests/AbstractTestFixture.cs
+++ b/OpenAI-DotNet-Tests/AbstractTestFixture.cs
@@ -6,9 +6,6 @@ using Microsoft.Extensions.Configuration;
 using System;
 using System.IO;
 using System.Net.Http;
-using System.Net.WebSockets;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace OpenAI.Tests
 {
@@ -42,24 +39,7 @@ namespace OpenAI.Tests
             OpenAIClient = new OpenAIClient(auth, settings, HttpClient)
             {
                 EnableDebug = true,
-                CreateWebsocketAsync = CreateWebsocketAsync
             };
-
-            return;
-
-            async Task<WebSocket> CreateWebsocketAsync(Uri uri, CancellationToken cancellationToken)
-            {
-                var websocketClient = webApplicationFactory.Server.CreateWebSocketClient();
-                websocketClient.ConfigureRequest = request =>
-                {
-                    foreach (var (key, value) in OpenAIClient.WebsocketHeaders)
-                    {
-                        request.Headers[key] = value;
-                    }
-                };
-                var websocket = await websocketClient.ConnectAsync(uri, cancellationToken);
-                return websocket;
-            }
         }
 
         private static Uri GetBaseAddressFromLaunchSettings()

--- a/OpenAI-DotNet/Authentication/OpenAISettings.cs
+++ b/OpenAI-DotNet/Authentication/OpenAISettings.cs
@@ -74,9 +74,7 @@ namespace OpenAI
             DeploymentId = string.Empty;
             BaseRequest = $"/{ApiVersion}/";
             BaseRequestUrlFormat = $"{ResourceName}{BaseRequest}{{0}}";
-            BaseWebSocketUrlFormat = ResourceName.Contains(Https)
-                ? $"{WSS}{domain}{BaseRequest}{{0}}"
-                : $"{WS}{domain}{BaseRequest}{{0}}";
+            BaseWebSocketUrlFormat = $"{WSS}{OpenAIDomain}{BaseRequest}{{0}}";
             UseOAuthAuthentication = true;
         }
 

--- a/OpenAI-DotNet/Extensions/WebSocket.cs
+++ b/OpenAI-DotNet/Extensions/WebSocket.cs
@@ -30,7 +30,6 @@ namespace OpenAI.Extensions
             Address = uri;
             RequestHeaders = requestHeaders ?? new Dictionary<string, string>();
             SubProtocols = subProtocols ?? new List<string>();
-            CreateWebsocketAsync = (_, _) => Task.FromResult<System.Net.WebSockets.WebSocket>(new ClientWebSocket());
             RunMessageQueue();
         }
 
@@ -122,9 +121,6 @@ namespace OpenAI.Extensions
         public async void Connect()
             => await ConnectAsync().ConfigureAwait(false);
 
-        // used for unit testing websocket server
-        internal Func<Uri, CancellationToken, Task<System.Net.WebSockets.WebSocket>> CreateWebsocketAsync;
-
         public async Task ConnectAsync(CancellationToken cancellationToken = default)
         {
             try
@@ -141,7 +137,7 @@ namespace OpenAI.Extensions
                 _lifetimeCts = new CancellationTokenSource();
                 using var cts = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeCts.Token, cancellationToken);
 
-                _socket = await CreateWebsocketAsync.Invoke(Address, cts.Token).ConfigureAwait(false);
+                _socket = new ClientWebSocket();
 
                 if (_socket is ClientWebSocket clientWebSocket)
                 {

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -29,8 +29,11 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>8.7.4</Version>
+    <Version>8.8.0</Version>
     <PackageReleaseNotes>
+Version 8.8.0
+- Improved RealtimeSession websocket support for proxies
+  - Proxy no longer handles the websocket connection directly, but instead initiates the connection to the OpenAI api directly using the ephemeral api key
 Version 8.7.4
 - Updated proxy support for the OpenAI-DotNet-Proxy package
 - Renamed OpenAIAuthentication.LoadFromEnv -&gt; OpenAIAuthentication.LoadFromEnvironment

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -16,14 +16,11 @@ using OpenAI.Responses;
 using OpenAI.Threads;
 using OpenAI.VectorStores;
 using System;
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Authentication;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace OpenAI
 {
@@ -289,27 +286,5 @@ namespace OpenAI
 
             return client;
         }
-
-        internal WebSocket CreateWebSocket(string url)
-        {
-            var websocket = new WebSocket(url, WebsocketHeaders);
-
-            if (CreateWebsocketAsync != null)
-            {
-                websocket.CreateWebsocketAsync = CreateWebsocketAsync;
-            }
-
-            return websocket;
-        }
-
-        // used to create unit test proxy server
-        internal Func<Uri, CancellationToken, Task<System.Net.WebSockets.WebSocket>> CreateWebsocketAsync = null;
-
-        internal IReadOnlyDictionary<string, string> WebsocketHeaders => new Dictionary<string, string>
-        {
-            { "User-Agent", "OpenAI-DotNet" },
-            { "OpenAI-Beta", "realtime=v1" },
-            { "Authorization", $"Bearer {OpenAIAuthentication.ApiKey}" }
-        };
     }
 }

--- a/OpenAI-DotNet/Realtime/ClientSecret.cs
+++ b/OpenAI-DotNet/Realtime/ClientSecret.cs
@@ -1,0 +1,40 @@
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace OpenAI.Realtime
+{
+    public sealed class ClientSecret
+    {
+        public ClientSecret() { }
+
+        public ClientSecret(int? expiresAfter = null)
+        {
+            ExpiresAfter = expiresAfter ?? 600;
+        }
+
+        [JsonInclude]
+        [JsonPropertyName("value")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string EphemeralApiKey { get; private set; }
+
+        [JsonInclude]
+        [JsonPropertyName("expires_at")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? ExpiresAtUnixTimeSeconds { get; private set; }
+
+        [JsonIgnore]
+        public DateTime? ExpiresAt
+            => ExpiresAtUnixTimeSeconds.HasValue
+                ? DateTimeOffset.FromUnixTimeSeconds(ExpiresAtUnixTimeSeconds.Value).UtcDateTime
+                : null;
+
+        [JsonInclude]
+        [JsonPropertyName("expires_after")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public ExpiresAfter ExpiresAfter { get; private set; }
+
+        public static implicit operator ClientSecret(int? expiresAfter) => new(expiresAfter);
+    }
+}

--- a/OpenAI-DotNet/Realtime/ExpiresAfter.cs
+++ b/OpenAI-DotNet/Realtime/ExpiresAfter.cs
@@ -1,0 +1,25 @@
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace OpenAI.Realtime
+{
+    public sealed class ExpiresAfter
+    {
+        public ExpiresAfter() { }
+
+        public ExpiresAfter(int seconds = 600)
+            => Seconds = seconds;
+
+        [JsonInclude]
+        [JsonPropertyName("anchor")]
+        public string Anchor { get; private set; } = "created_at";
+
+        [JsonInclude]
+        [JsonPropertyName("seconds")]
+        public int Seconds { get; private set; } = 600;
+
+        public static implicit operator ExpiresAfter(int seconds)
+            => new(seconds);
+    }
+}

--- a/OpenAI-DotNet/Realtime/RealtimeEndpoint.cs
+++ b/OpenAI-DotNet/Realtime/RealtimeEndpoint.cs
@@ -3,6 +3,7 @@
 using OpenAI.Extensions;
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,7 +37,23 @@ namespace OpenAI.Realtime
                 queryParameters["model"] = model;
             }
 
-            var session = new RealtimeSession(client.CreateWebSocket(GetUrl(queryParameters: queryParameters)), EnableDebug);
+            var payload = JsonSerializer.Serialize(configuration).ToJsonStringContent();
+            var createSessionResponse = await HttpClient.PostAsync(GetUrl("/sessions"), payload, cancellationToken).ConfigureAwait(false);
+            var createSession = await createSessionResponse.DeserializeAsync<SessionConfiguration>(EnableDebug, payload, client, cancellationToken).ConfigureAwait(false);
+
+            if (createSession == null ||
+                string.IsNullOrWhiteSpace(createSession.ClientSecret?.EphemeralApiKey))
+            {
+                throw new InvalidOperationException("Failed to create a session. Ensure the configuration is valid and the API key is set.");
+            }
+
+            var websocket = new WebSocket(GetUrl(queryParameters: queryParameters), new Dictionary<string, string>
+            {
+                { "User-Agent", "OpenAI-DotNet" },
+                { "OpenAI-Beta", "realtime=v1" },
+                { "Authorization", $"Bearer {createSession.ClientSecret.EphemeralApiKey}" }
+            });
+            var session = new RealtimeSession(websocket, EnableDebug);
             var sessionCreatedTcs = new TaskCompletionSource<SessionResponse>();
 
             try
@@ -46,7 +63,6 @@ namespace OpenAI.Realtime
                 await session.ConnectAsync(cancellationToken).ConfigureAwait(false);
                 var sessionResponse = await sessionCreatedTcs.Task.WithCancellation(cancellationToken).ConfigureAwait(false);
                 session.Configuration = sessionResponse.SessionConfiguration;
-                await session.SendAsync(new UpdateSessionRequest(configuration), cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/OpenAI-DotNet/Realtime/SessionConfiguration.cs
+++ b/OpenAI-DotNet/Realtime/SessionConfiguration.cs
@@ -24,10 +24,12 @@ namespace OpenAI.Realtime
             IEnumerable<Tool> tools = null,
             string toolChoice = null,
             float? temperature = null,
-            int? maxResponseOutputTokens = null)
+            int? maxResponseOutputTokens = null,
+            int? expiresAfter = null)
         {
+            ClientSecret = new ClientSecret(expiresAfter);
             Model = string.IsNullOrWhiteSpace(model.Id)
-                ? "gpt-4o-realtime-preview"
+                ? Models.Model.GPT4oRealtime
                 : model;
             Modalities = modalities;
             Voice = voice ?? OpenAI.Voice.Alloy;
@@ -92,6 +94,11 @@ namespace OpenAI.Realtime
             Temperature = temperature;
             MaxResponseOutputTokens = maxResponseOutputTokens;
         }
+
+        [JsonInclude]
+        [JsonPropertyName("client_secret")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public ClientSecret ClientSecret { get; private set; }
 
         [JsonInclude]
         [JsonPropertyName("modalities")]


### PR DESCRIPTION
- Improved RealtimeSession websocket support for proxies
  - Proxy no longer handles the websocket connection directly, but instead initiates the connection to the OpenAI api directly using the ephemeral api key ## OpenAI-DotNet-Proxy 8.8.0
- Removed Websocket handling from the proxy