### PR TITLE
OpenAI-DotNet 8.8.6

### DIFF
--- a/OpenAI-DotNet-Proxy/OpenAI-DotNet-Proxy.csproj
+++ b/OpenAI-DotNet-Proxy/OpenAI-DotNet-Proxy.csproj
@@ -22,8 +22,10 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SignAssembly>false</SignAssembly>
     <ImplicitUsings>false</ImplicitUsings>
-    <Version>8.8.2</Version>
+    <Version>8.8.6</Version>
     <PackageReleaseNotes>
+Version 8.8.6
+- Fix unimplemented routePrefix in OpenAIProxyStartup.CreateWebApplication
 Version 8.8.2
 - Updated forwarded request headers
 Version 8.8.0

--- a/OpenAI-DotNet-Proxy/Proxy/OpenAIProxy.cs
+++ b/OpenAI-DotNet-Proxy/Proxy/OpenAIProxy.cs
@@ -17,6 +17,7 @@ namespace OpenAI.Proxy
     /// </summary>
     public class OpenAIProxy
     {
+        private string routePrefix = "";
         private OpenAIClient openAIClient;
         private IAuthenticationFilter authenticationFilter;
 
@@ -46,7 +47,7 @@ namespace OpenAI.Proxy
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapGet("/health", HealthEndpoint);
-                endpoints.MapOpenAIEndpoints(openAIClient, authenticationFilter);
+                endpoints.MapOpenAIEndpoints(openAIClient, authenticationFilter, routePrefix);
             });
         }
 
@@ -92,7 +93,10 @@ namespace OpenAI.Proxy
             builder.Services.AddSingleton(openAIClient);
             builder.Services.AddSingleton<IAuthenticationFilter, T>();
             var app = builder.Build();
-            var startup = new OpenAIProxy();
+            var startup = new OpenAIProxy
+            {
+                routePrefix = routePrefix
+            };
             startup.Configure(app, app.Environment);
             return app;
         }

--- a/OpenAI-DotNet-Tests-Proxy/Program.cs
+++ b/OpenAI-DotNet-Tests-Proxy/Program.cs
@@ -15,6 +15,7 @@ namespace OpenAI.Tests.Proxy
     {
         private const string TestUserToken = "aAbBcCdDeE123456789";
 
+        // ReSharper disable once ClassNeverInstantiated.Local
         private class AuthenticationFilter : AbstractAuthenticationFilter
         {
             /// <inheritdoc />

--- a/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
+++ b/OpenAI-DotNet-Tests/TestFixture_13_Realtime.cs
@@ -59,6 +59,7 @@ namespace OpenAI.Tests
                 await session.SendAsync(new ConversationItemCreateRequest("Hello!"), cts.Token);
                 await session.SendAsync(new CreateResponseRequest(), cts.Token);
                 await session.SendAsync(new InputAudioBufferAppendRequest(new ReadOnlyMemory<byte>(new byte[1024 * 4])), cts.Token);
+                await session.SendAsync(new UpdateSessionRequest(new SessionConfiguration(model: Model.Transcribe_GPT_4o_Mini, instructions: "You are a fearsome dinosaur. Rawr!", tools: tools)), cts.Token);
                 await session.SendAsync(new ConversationItemCreateRequest("Goodbye!"), cts.Token);
                 await session.SendAsync(new CreateResponseRequest(), cts.Token);
 

--- a/OpenAI-DotNet/OpenAI-DotNet.csproj
+++ b/OpenAI-DotNet/OpenAI-DotNet.csproj
@@ -29,8 +29,10 @@ More context [on Roger Pincombe's blog](https://rogerpincombe.com/openai-dotnet-
     <AssemblyOriginatorKeyFile>OpenAI-DotNet.pfx</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>8.8.4</Version>
+    <Version>8.8.6</Version>
     <PackageReleaseNotes>
+Version 8.8.6
+- Fix Realtime.UpdateSessionRequests failing to update session due to extra client secret data
 Version 8.8.4
 - Fix RealtimeSessionConfiguration and CreateResponseRequest model parameter overriding prompt settings
 - Fix Threads.MessageResponse.Status not being properly set to Completed

--- a/OpenAI-DotNet/OpenAIClient.cs
+++ b/OpenAI-DotNet/OpenAIClient.cs
@@ -118,6 +118,7 @@ namespace OpenAI
         internal static JsonSerializerOptions JsonSerializationOptions { get; } = new()
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            ReferenceHandler = ReferenceHandler.IgnoreCycles,
             Converters =
             {
                 new JsonStringEnumConverterFactory(),
@@ -129,7 +130,6 @@ namespace OpenAI
                 new FilterConverter(),
                 new ToolConverter(),
             },
-            ReferenceHandler = ReferenceHandler.IgnoreCycles
         };
 
         /// <summary>

--- a/OpenAI-DotNet/Realtime/SessionConfiguration.cs
+++ b/OpenAI-DotNet/Realtime/SessionConfiguration.cs
@@ -180,7 +180,7 @@ namespace OpenAI.Realtime
         [JsonInclude]
         [JsonPropertyName("client_secret")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public ClientSecret ClientSecret { get; private set; }
+        public ClientSecret ClientSecret { get; internal set; }
 
         /// <summary>
         /// The set of modalities the model can respond with.

--- a/OpenAI-DotNet/Realtime/UpdateSessionRequest.cs
+++ b/OpenAI-DotNet/Realtime/UpdateSessionRequest.cs
@@ -19,6 +19,7 @@ namespace OpenAI.Realtime
         public UpdateSessionRequest(SessionConfiguration configuration)
         {
             Configuration = configuration;
+            Configuration.ClientSecret = null;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
- Fix Realtime.UpdateSessionRequests failing to update session due to extra client secret data

## OpenAI-DotNet-Proxy 8.8.6
- Fix unimplemented routePrefix in OpenAIProxyStartup.CreateWebApplication